### PR TITLE
feat: Add install script for Funnel

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -23,6 +23,7 @@ RELEASE_URL=""
 if [ -z "$VERSION_TAG" ]; then
     echo "No version specified. Fetching the latest release..."
     RELEASE_URL=$(get_latest_release_url)
+    VERSION_TAG=$(curl -s $RELEASE_URL | grep '"tag_name":' | cut -d '"' -f 4)
 else
     echo "Fetching release for version $VERSION_TAG..."
     RELEASE_URL=$(get_tag_release_url $VERSION_TAG)
@@ -49,14 +50,14 @@ CHECKSUM_FILE="funnel_${VERSION_TAG}_checksums.txt"
 ASSETS=$(curl -s $RELEASE_URL | grep "browser_download_url" | cut -d '"' -f 4)
 
 # Download the tar.gz file and checksums.txt for the detected OS and Arch
-echo "Downloading Funnel for $OS $ARCH..."
+echo "Downloading Funnel $VERSION_TAG for $OS $ARCH..."
 for asset in $ASSETS; do
     if [[ $asset == *"${OS}-${ARCH}"* && $asset == *".tar.gz"* ]]; then
         TAR_URL=$asset
         TAR_NAME=$(basename $asset)
-        curl -LsO $TAR_URL
+        curl -L --progress-bar -o $TAR_NAME $TAR_URL
     elif [[ $asset == *"$CHECKSUM_FILE"* ]]; then
-        curl -o $CHECKSUM_FILE -LsO $asset
+        curl -L --progress-bar -o $CHECKSUM_FILE $asset
     fi
 done
 


### PR DESCRIPTION
# Overview

This PR adds an initial install script to help with installing Funnel via a one line `curl` command:

## Installing Latest Release

```sh
➜ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/ohsu-comp-bio/funnel/refs/heads/develop/install.sh)"

Installing Funnel...
No version specified. Fetching the latest release...
Downloading Funnel v0.11.6 for darwin arm64...
############################### 100.0%
Verifying checksum...
Extracting the package...
Installing Funnel to $HOME/.local/bin...
Installation successful: $HOME/.local/bin/funnel

git commit: 046db6f1
git branch: feature/plugins
git upstream: https://github.com/ohsu-comp-bio/funnel
version: v0.11.6

Run 'funnel --help' for more info
```

## Installing Tagged Release (e.g. `0.11.3`)

```sh
➜ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/ohsu-comp-bio/funnel/refs/heads/develop/install.sh)" -- 0.11.3

Installing Funnel...
Fetching release for version 0.11.3...
Downloading Funnel 0.11.3 for darwin arm64...
############################### 100.0%
Verifying checksum...
Extracting the package...
Installing Funnel to $HOME/.local/bin...
Installation successful: $HOME/.local/bin/funnel

git commit: bcf6819c
git branch: master
git upstream: https://github.com/ohsu-comp-bio/funnel
version: 0.11.3

Run 'funnel --help' for more info
```

## Inspiration

> [!TIP]
> This follows similar examples in the following projects:
> - [uv](https://github.com/astral-sh/uv#installation)
> - [Rust](https://rust-lang.org/tools/install/)
> - [nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
> - [Homebrew](https://brew.sh/#install)