### PR TITLE
`fix/invalid-state-transition` → `develop`

### DIFF
--- a/config/kubernetes/executor-job.yaml
+++ b/config/kubernetes/executor-job.yaml
@@ -1,3 +1,4 @@
+# TODO: Remove all K8s artifacts in favor of Helm configs (confusing to have both)
 # Task Executor
 apiVersion: batch/v1
 kind: Job

--- a/database/boltdb/events.go
+++ b/database/boltdb/events.go
@@ -173,6 +173,9 @@ func transitionTaskState(tx *bolt.Tx, id string, target tes.State) error {
 		return fmt.Errorf("Won't switch between two terminal states: %s -> %s",
 			current, target)
 
+	// In case where restarts of executor are allowed, this line should not be encountered
+	// e.g. Accessing invalid object shpuld be SYSTEM_ERROR every time,
+	// but if a retry mechanism would work (e.g. unavailable for a few seconds), then Task Worker should allow Executor to restart as expected.
 	case tes.TerminalState(current) && !tes.TerminalState(target):
 		// Error when trying to switch out of a terminal state to a non-terminal one.
 		return fmt.Errorf("Unexpected transition from %s to %s", current.String(), target.String())

--- a/database/mongodb/events.go
+++ b/database/mongodb/events.go
@@ -37,6 +37,9 @@ func (db *MongoDB) WriteEvent(ctx context.Context, req *events.Event) error {
 
 	case events.Type_TASK_STATE:
 		retrier := util.NewRetrier()
+		// TODO: This could be where the invalid state transition errors are originating from (credit @Sai)
+		// Check how this interacts with K8s BackoffLimit on Job spec
+		// Ideally we would have users be able to control their own retry policies outside of internal Funnel's logic
 		retrier.ShouldRetry = func(err error) bool {
 			_, isTransitionError := err.(*tes.TransitionError)
 			return !isTransitionError && err != tes.ErrNotFound && err != tes.ErrNotPermitted

--- a/tes/states.go
+++ b/tes/states.go
@@ -21,6 +21,7 @@ type TransitionError struct {
 }
 
 func (te *TransitionError) Error() string {
+	// TODO: This error is being thrown after valid worker restarts (e.g. K8s)
 	return fmt.Sprintf("invalid state transition from %s to %s",
 		te.From.String(), te.To.String())
 }


### PR DESCRIPTION
# Overview 🌀

This PR resolves the Invalid State Transition error when resubmitting tasks via an external retry mechanism (e.g. K8s [BackoffLimit](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy)).

## Current Behavior ⚠️ 

<details><summary><code>s3-invalid.json</code></summary>
<p>

```json
{
  "name": "S3 Storage example (invalid)",
  "description": "Task inputs and outputs can be Cloud Storage URLs (Invalid Test)",
  "executors": [
    {
      "image": "ubuntu",
      "command": ["md5sum", "/tmp/README.md"]
    }
  ],
  "inputs": [
    {
      "name": "input",
      "description": "Download a file from S3 Storage",
      "url": "s3://funnel-testing-east/ERROR",    <----- Non-existent object set here
      "path": "/tmp/README.md"
    }
  ]
}
```

</p>
</details> 

```sh
➜ funnel task create examples/s3-invalid.json
<TASK ID>

➜ funnel task get <TASK ID> --view MINIMAL
{
  "id":  "<TASK ID>",
  "state":  "SYSTEM_ERROR"
}

➜ kubectl get jobs/<TASK ID>
NAME          COMPLETIONS   DURATION
<TASK ID>     0/1           13m     <---- Worker

➜ kubectl logs jobs/<TASK ID>
{"error":"invalid state transition from SYSTEM_ERROR to INITIALIZING","msg":"error writing event"}
{"error":"genericS3: stat object ERROR in bucket funnel-testing-east: The specified key does not exist."}
{"msg":"TASK_STATE","ns":"worker","state":"SYSTEM_ERROR","taskID":"<TASK ID>"}
```

> [!NOTE]
>
> Tested with Helm Charts [0.1.71](https://github.com/ohsu-comp-bio/helm-charts/commit/96bc68cda35eddce88b684eff46a594e9d0864c5) ([2025-12-14](https://github.com/ohsu-comp-bio/funnel/commit/24bff9aabb9ed9b4862a971629859c9f3d724643)) and [0.1.75](https://github.com/ohsu-comp-bio/helm-charts/releases/tag/funnel-0.1.75) ([2025-12-22](https://github.com/ohsu-comp-bio/funnel/commit/e2ee968ba7c6f150bb8d1d285e8fa496146fe9f1)):
>
> ```sh
> ➜ helm repo update ohsu
> Update Complete. ⎈Happy Helming!⎈
>
> ➜ helm search repo funnel --versions
> NAME            CHART VERSION   APP VERSION     DESCRIPTION
> ohsu/funnel     0.1.75          2025-12-22      A toolkit for distributed task execution ⚙️
> ...
> ohsu/funnel     0.1.71          2025-12-14      A toolkit for distributed task execution ⚙️
>
> ➜ helm upgrade --install funnel ohsu/funnel -f values.yaml --version 0.1.71
> Release "funnel" has been upgraded. Happy Helming!
> ```
