### PR TITLE
Fix/enable config output

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,3 @@ Funnel is an implementation of the [GA4GH Task Execution Schemas](https://github
 Funnel provides an API server, multiple storage backends (local FS, S3, Google Bucket, etc.), multiple compute backends (local, HTCondor, Google Cloud, etc.), and a web dashboard.
 
 https://ohsu-comp-bio.github.io/funnel/
-

--- a/cmd/server/run.go
+++ b/cmd/server/run.go
@@ -55,6 +55,8 @@ type Database interface {
 
 // NewServer returns a new Funnel server + scheduler based on the given config.
 func NewServer(ctx context.Context, conf *config.Config, log *logger.Logger) (*Server, error) {
+	log.Debug("NewServer", "config", conf.Safe())
+
 	var database Database
 	var reader tes.ReadOnlyServer
 	var nodes scheduler.SchedulerServiceServer

--- a/cmd/worker/run.go
+++ b/cmd/worker/run.go
@@ -30,6 +30,8 @@ func Run(ctx context.Context, conf *config.Config, log *logger.Logger, opts *Opt
 
 // NewWorker returns a new Funnel worker based on the given config.
 func NewWorker(ctx context.Context, conf *config.Config, log *logger.Logger, opts *Options) (*worker.DefaultWorker, error) {
+	log.Debug("NewWorker", "config", conf.Safe())
+
 	err := validateConfig(conf, opts)
 	if err != nil {
 		return nil, fmt.Errorf("validating config: %v", err)

--- a/compute/kubernetes/backend.go
+++ b/compute/kubernetes/backend.go
@@ -91,6 +91,7 @@ func (b Backend) CheckBackendParameterSupport(task *tes.Task) error {
 func (b *Backend) WriteEvent(ctx context.Context, ev *events.Event) error {
 	// TODO: Should this be moved to the switch statement so it's only run on TASK_CREATED?
 	var taskConfig *config.Config = b.conf
+	b.log.Debug("taskConfig", "before plugin", taskConfig.Safe())
 	if b.conf.Plugins != nil {
 		resp, ok := ctx.Value("pluginResponse").(*proto.JobResponse)
 		if !ok {
@@ -103,6 +104,7 @@ func (b *Backend) WriteEvent(ctx context.Context, ev *events.Event) error {
 			return fmt.Errorf("Failed to merge plugin config %v", err)
 		}
 	}
+	b.log.Debug("taskConfig", "after plugin", taskConfig.Safe())
 
 	switch ev.Type {
 	case events.Type_TASK_CREATED:

--- a/compute/scheduler/node.go
+++ b/compute/scheduler/node.go
@@ -16,6 +16,7 @@ import (
 // NewNodeProcess returns a new Node instance
 func NewNodeProcess(ctx context.Context, conf *config.Config, factory Worker, log *logger.Logger) (*NodeProcess, error) {
 	log = log.WithFields("nodeID", conf.Node.ID)
+	log.Debug("NewNode", "config", conf.Safe())
 
 	cli, err := NewClient(ctx, conf.RPCClient)
 	if err != nil {

--- a/config/safe.go
+++ b/config/safe.go
@@ -68,6 +68,9 @@ func (c *Config) Safe() *Config {
 
 	if safe.GenericS3 != nil {
 		for i, s3 := range safe.GenericS3 {
+			if s3 == nil {
+				continue
+			}
 			gs3 := *s3
 			gs3.Key = redact(gs3.Key)
 			gs3.Secret = redact(gs3.Secret)
@@ -99,6 +102,9 @@ func (c *Config) Safe() *Config {
 
 		if s.BasicAuth != nil {
 			for i, cred := range s.BasicAuth {
+				if cred == nil {
+					continue
+				}
 				bc := *cred
 				bc.Password = redact(bc.Password)
 				s.BasicAuth[i] = &bc
@@ -135,7 +141,7 @@ func (c *Config) Safe() *Config {
 		safe.FTPStorage = &ftp
 	}
 
-	return &safe
+	return safe
 }
 
 func redact(s string) string {

--- a/config/safe.go
+++ b/config/safe.go
@@ -25,7 +25,9 @@ func (c *Config) Safe() *Config {
 
 	if safe.Postgres != nil {
 		p := *safe.Postgres
+		p.User = redact(p.User)
 		p.Password = redact(p.Password)
+		p.AdminUser = redact(p.AdminUser)
 		p.AdminPassword = redact(p.AdminPassword)
 		safe.Postgres = &p
 	}
@@ -144,8 +146,8 @@ func (c *Config) Safe() *Config {
 	return safe
 }
 
-func redact(s string) string {
-	if s == "" {
+func redact(str string) string {
+	if str == "" {
 		return ""
 	}
 	return "***"

--- a/config/safe.go
+++ b/config/safe.go
@@ -139,5 +139,8 @@ func (c *Config) Safe() *Config {
 }
 
 func redact(s string) string {
+	if s == "" {
+		return ""
+	}
 	return "***"
 }

--- a/config/safe.go
+++ b/config/safe.go
@@ -1,12 +1,20 @@
 package config
 
+import "google.golang.org/protobuf/proto"
+
 // Safe returns a copy of the config with sensitive fields redacted
 func (c *Config) Safe() *Config {
 	if c == nil {
 		return nil
 	}
 
-	safe := *c
+	cloned := proto.Clone(c)
+	safe, ok := cloned.(*Config)
+	if !ok {
+		// Fallback: if cloning fails for some unexpected reason, avoid redacting the live config.
+		copy := *c
+		safe = &copy
+	}
 
 	// Database credentials
 	if safe.MongoDB != nil {

--- a/config/safe.go
+++ b/config/safe.go
@@ -1,0 +1,135 @@
+package config
+
+// Safe returns a copy of the config with sensitive fields redacted
+func (c *Config) Safe() *Config {
+	if c == nil {
+		return nil
+	}
+
+	safe := *c
+
+	// Database credentials
+	if safe.MongoDB != nil {
+		m := *safe.MongoDB
+		m.Password = redact(m.Password)
+		safe.MongoDB = &m
+	}
+
+	if safe.Postgres != nil {
+		p := *safe.Postgres
+		p.Password = redact(p.Password)
+		p.AdminPassword = redact(p.AdminPassword)
+		safe.Postgres = &p
+	}
+
+	if safe.Elastic != nil {
+		e := *safe.Elastic
+		e.Password = redact(e.Password)
+		e.APIKey = redact(e.APIKey)
+		e.ServiceToken = redact(e.ServiceToken)
+		safe.Elastic = &e
+	}
+
+	// Cloud provider credentials
+	if safe.AWSBatch != nil && safe.AWSBatch.AWSConfig != nil {
+		ab := *safe.AWSBatch
+		ac := *ab.AWSConfig
+		ac.Key = redact(ac.Key)
+		ac.Secret = redact(ac.Secret)
+		ab.AWSConfig = &ac
+		safe.AWSBatch = &ab
+	}
+
+	if safe.DynamoDB != nil && safe.DynamoDB.AWSConfig != nil {
+		d := *safe.DynamoDB
+		ac := *d.AWSConfig
+		ac.Key = redact(ac.Key)
+		ac.Secret = redact(ac.Secret)
+		d.AWSConfig = &ac
+		safe.DynamoDB = &d
+	}
+
+	if safe.AmazonS3 != nil && safe.AmazonS3.AWSConfig != nil {
+		s3 := *safe.AmazonS3
+		ac := *s3.AWSConfig
+		ac.Key = redact(ac.Key)
+		ac.Secret = redact(ac.Secret)
+		s3.AWSConfig = &ac
+		safe.AmazonS3 = &s3
+	}
+
+	if safe.GenericS3 != nil {
+		for i, s3 := range safe.GenericS3 {
+			gs3 := *s3
+			gs3.Key = redact(gs3.Key)
+			gs3.Secret = redact(gs3.Secret)
+			safe.GenericS3[i] = &gs3
+		}
+	}
+
+	if safe.PubSub != nil {
+		ps := *safe.PubSub
+		ps.CredentialsFile = redact(ps.CredentialsFile)
+		safe.PubSub = &ps
+	}
+
+	if safe.Datastore != nil {
+		ds := *safe.Datastore
+		ds.CredentialsFile = redact(ds.CredentialsFile)
+		safe.Datastore = &ds
+	}
+
+	if safe.GoogleStorage != nil {
+		gs := *safe.GoogleStorage
+		gs.CredentialsFile = redact(gs.CredentialsFile)
+		safe.GoogleStorage = &gs
+	}
+
+	// Auth credentials
+	if safe.Server != nil {
+		s := *safe.Server
+
+		if s.BasicAuth != nil {
+			for i, cred := range s.BasicAuth {
+				bc := *cred
+				bc.Password = redact(bc.Password)
+				s.BasicAuth[i] = &bc
+			}
+		}
+
+		if s.OidcAuth != nil {
+			oa := *s.OidcAuth
+			oa.ClientSecret = redact(oa.ClientSecret)
+			s.OidcAuth = &oa
+		}
+
+		safe.Server = &s
+	}
+
+	if safe.RPCClient != nil && safe.RPCClient.Credential != nil {
+		rpc := *safe.RPCClient
+		cred := *rpc.Credential
+		cred.Password = redact(cred.Password)
+		rpc.Credential = &cred
+		safe.RPCClient = &rpc
+	}
+
+	// Storage credentials
+	if safe.Swift != nil {
+		sw := *safe.Swift
+		sw.Password = redact(sw.Password)
+		safe.Swift = &sw
+	}
+
+	if safe.FTPStorage != nil {
+		ftp := *safe.FTPStorage
+		ftp.Password = redact(ftp.Password)
+		safe.FTPStorage = &ftp
+	}
+
+	return &safe
+}
+
+func redact(s string) string {
+	return "***"
+}


### PR DESCRIPTION
# Overview ⚙️

This PR re-enables the config output that was removed in [v0.11.8](https://github.com/ohsu-comp-bio/funnel/releases/tag/v0.11.8) (Commits [d5f0655](https://github.com/ohsu-comp-bio/funnel/commit/d5f0655#diff-397ac292e94e05a7d95ed3ffa4862cb1635a71ba0ef91d37be8c67caec9f02f4L58-L59) + [76ac374](https://github.com/ohsu-comp-bio/funnel/commit/76ac374)) with one caveat — it sanitizes/redacts sensitive fields in config/safe.go

> [!IMPORTANT]
>
> Ideally this is a short-term fix while we add secret manager support to Funnel (to avoid storing credentials in plain-text anywhere)...

## Current Behavior ⚠️

> Current behavior is to simply not output the config at all, so the following is really the behavior for Funnel versions before v0.11.8
>
> **Example:** Postgres credentials

```sh
➜ funnel server run --Logger.level debug
server               NewServer
config               {
                      ...
                      "Logger":  {
                        "level":  "debug",
                      },
                      "Postgres":  {
                        "Host":  "localhost",
                        "Database":  "funnel",
                        "User":  "funnel",         <---- Plain-text credentials ⚠️
                        "Password":  "example",
                        "AdminUser":  "postgres",
                        "AdminPassword":  "example",
                        "Timeout":  {
                          "duration":  "300s"
                        }
                      }
```

## New Behavior ✅ 

> **Example:** Postgres credentials

```sh
➜ funnel server run --Logger.level debug

server               NewServer
config               {
                      ...
                      "Logger":  {
                        "level":  "debug",
                      },
                      "Postgres": {
                        "Host": "localhost:5432",
                        "Database": "funnel",
                        "User": "***",         <---- Redacted credentials ✅ 
                        "Password": "***",
                        "AdminUser": "***",
                        "AdminPassword": "***",
                        "Timeout": {
                          "duration": "30s"
                        }
                      }
```

## Open Questions 🌀

- Will users ever need to see unredacted fields in the debug output?
  - If so we can add a "unsafe" config option that outputs the entire unredacted config
- Future changes to the config will need to be considered and added on a case-by-case basis unfortunately...
