### PR TITLE
fix: Return `400` instead of `500` when canceling completed tasks

### DIFF
--- a/cmd/util/config.go
+++ b/cmd/util/config.go
@@ -6,6 +6,7 @@ import (
 
 	"dario.cat/mergo"
 	"github.com/ohsu-comp-bio/funnel/config"
+	"google.golang.org/protobuf/proto"
 )
 
 // MergeConfigFileWithFlags is a util used by server commands that use flags to set
@@ -17,10 +18,14 @@ func MergeConfigFileWithFlags(file string, flagConf *config.Config) (*config.Con
 
 	// Only parse file if it exists
 	if file != "" {
-		err := config.ParseFile(file, conf)
+		fileConf := config.EmptyConfig()
+		err := config.ParseFile(file, fileConf)
 		if err != nil {
 			return conf, err
 		}
+
+		// Use proto.Merge to properly merge nested fields
+		proto.Merge(conf, fileConf)
 	}
 
 	// Merge defaults into file config (file values take priority, including false values)

--- a/cmd/worker/run.go
+++ b/cmd/worker/run.go
@@ -181,7 +181,7 @@ func (e *eventWriterBuilder) Add(ctx context.Context, name string, conf *config.
 	var err error
 	var writer events.Writer
 
-	switch name {
+	switch strings.ToLower(name) {
 	case "log":
 		writer = &events.Logger{Log: log}
 	case "boltdb", "badger", "grpc", "rpc":
@@ -216,7 +216,7 @@ func validateConfig(conf *config.Config, opts *Options) error {
 	// only a subset of event writers are supported.
 	if opts.TaskFile != "" || opts.TaskBase64 != "" {
 		for _, e := range conf.EventWriters {
-			if e != "log" && e != "kafka" && e != "pubsub" {
+			if strings.ToLower(e) != "log" && strings.ToLower(e) != "kafka" && strings.ToLower(e) != "pubsub" {
 				return fmt.Errorf("event writer %q is not supported with a task file/string reader", e)
 			}
 		}

--- a/compute/kubernetes/backend.go
+++ b/compute/kubernetes/backend.go
@@ -4,7 +4,6 @@ package kubernetes
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"time"
 
@@ -21,6 +20,9 @@ import (
 	"github.com/ohsu-comp-bio/funnel/plugins/proto"
 	"github.com/ohsu-comp-bio/funnel/tes"
 	"github.com/ohsu-comp-bio/funnel/util/k8sutil"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // Backend represents the K8s backend.
@@ -79,7 +81,7 @@ func (b Backend) CheckBackendParameterSupport(task *tes.Task) error {
 	for k := range taskBackendParameters {
 		_, ok := b.backendParameters[k]
 		if !ok {
-			return errors.New("backend parameters not supported")
+			return status.Errorf(codes.InvalidArgument, "backend parameters not supported: %s", k)
 		}
 	}
 

--- a/compute/local/backend.go
+++ b/compute/local/backend.go
@@ -3,7 +3,6 @@ package local
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/imdario/mergo"
@@ -13,6 +12,9 @@ import (
 	"github.com/ohsu-comp-bio/funnel/logger"
 	"github.com/ohsu-comp-bio/funnel/plugins/proto"
 	"github.com/ohsu-comp-bio/funnel/tes"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // NewBackend returns a new local Backend instance.
@@ -38,7 +40,7 @@ func (b Backend) CheckBackendParameterSupport(task *tes.Task) error {
 	for k := range taskBackendParameters {
 		_, ok := b.backendParameters[k]
 		if !ok {
-			return errors.New("backend parameters not supported")
+			return status.Errorf(codes.InvalidArgument, "backend parameters not supported: %s", k)
 		}
 	}
 

--- a/database/postgres/events.go
+++ b/database/postgres/events.go
@@ -11,6 +11,9 @@ import (
 	"github.com/ohsu-comp-bio/funnel/server"
 	"github.com/ohsu-comp-bio/funnel/tes"
 	"github.com/ohsu-comp-bio/funnel/util"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // WriteEvent creates an event for the server to handle.
@@ -57,6 +60,13 @@ func (db *Postgres) WriteEvent(ctx context.Context, req *events.Event) error {
 	case events.Type_TASK_STATE:
 		retrier := util.NewRetrier()
 		retrier.ShouldRetry = func(err error) bool {
+			// Check if it's an InvalidArgument (400) gRPC error
+			if st, ok := status.FromError(err); ok {
+				if st.Code() == codes.InvalidArgument {
+					return false
+				}
+			}
+
 			_, isTransitionError := err.(*tes.TransitionError)
 			shouldRetry := !isTransitionError &&
 				err != tes.ErrNotFound &&
@@ -77,8 +87,8 @@ func (db *Postgres) WriteEvent(ctx context.Context, req *events.Event) error {
 			// Validate state transition
 			to := req.GetState()
 			if err = tes.ValidateTransition(state, to); err != nil {
-				logger.Debug("postgres: invalid state transition", "taskID", req.Id, "from", state, "to", to, "error", err)
-				return err
+				logger.Debug("postgres:", err.Error())
+				return status.Error(codes.InvalidArgument, err.Error())
 			}
 
 			newVersion := time.Now().UnixNano()
@@ -187,16 +197,10 @@ func (db *Postgres) WriteEvent(ctx context.Context, req *events.Event) error {
 			SET data = jsonb_set(data, $1::text[], $2::jsonb, true)
 			WHERE id = $3
 		`
-		fmt.Println("DEBUG: jsonPath:", jsonPath)
-		fmt.Println("DEBUG: jsonValue:", jsonValue)
-		fmt.Println("DEBUG: updateSQL:", updateSQL)
 		jsonVal, _ := json.Marshal(jsonValue)
-		fmt.Println("DEBUG: jsonVal:", string(jsonVal))
 		_, err := db.client.Exec(ctx, updateSQL, jsonPath, jsonVal, selector)
 
 		// Log error
-		logger.Error("Postgres WriteEvent", "Error", err)
-		fmt.Println("DEBUG: Postgres WriteEvent error:", err)
 		return err
 
 	// System Log
@@ -223,10 +227,8 @@ func (db *Postgres) WriteEvent(ctx context.Context, req *events.Event) error {
 		}
 
 		currentLogs = append(currentLogs, logValue)
-		fmt.Printf("DEBUG: System logs for task %s: adding '%s', total count: %d\n", selector, logValue, len(currentLogs))
 
 		newLogsJSON, _ := json.Marshal(currentLogs)
-		fmt.Printf("DEBUG: Updated system logs JSON: %s\n", string(newLogsJSON))
 
 		updateSQL := `
             UPDATE tasks

--- a/events/computer.go
+++ b/events/computer.go
@@ -2,9 +2,11 @@ package events
 
 import (
 	"context"
-	"errors"
 
 	tes "github.com/ohsu-comp-bio/funnel/tes"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type Computer interface {
@@ -21,7 +23,7 @@ func (b Backend) CheckBackendParameterSupport(task *tes.Task) error {
 	for k := range taskBackendParameters {
 		_, ok := b.BackendParameters[k]
 		if !ok {
-			return errors.New("backend parameters not supported")
+			return status.Errorf(codes.InvalidArgument, "backend parameters not supported: %s", k)
 		}
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net"
 	"net/http"
-	"strings"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -93,11 +92,7 @@ func customErrorHandler(ctx context.Context, mux *runtime.ServeMux, marshaler ru
 	case codes.DeadlineExceeded: // 504
 		w.WriteHeader(http.StatusGatewayTimeout)
 	default:
-		if strings.Contains(st.Message(), "backend parameters not supported") {
-			w.WriteHeader(http.StatusBadRequest) // 400
-		} else {
-			w.WriteHeader(http.StatusInternalServerError) // 500
-		}
+		w.WriteHeader(http.StatusInternalServerError) // 500
 	}
 
 	// Write the error message


### PR DESCRIPTION
# Overview 🌀

This PR updates Funnel's response code from `500` to `400` when a terminal state task attempts to be canceled.

## Old Behavior ⚠️

```sh
➜ curl -i -X POST localhost:8000/v1/tasks/<TASK ID>:cancel
HTTP/1.1 500 Internal Server Error

# Postgres
{
  "error": "postgres: failed to find task state of task: d6h1gspurbu2fqlbjnd0"
}

# BoltDB
{
  "error": "Won't switch between two terminal states: COMPLETE -> CANCELED"
}
```

## New Behavior ✅

```sh
➜ curl -i -X POST localhost:8000/v1/tasks/<TASK ID>:cancel
HTTP/1.1 400 Bad Request
{
  "error": "invalid state transition from COMPLETE to CANCELED"
}
```