### PR TITLE
fix: cancel task: Replace `400` error with `200` + message for user

### DIFF
--- a/cmd/task/cancel.go
+++ b/cmd/task/cancel.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -19,13 +20,23 @@ func Cancel(server string, ids []string, writer io.Writer) error {
 	res := []string{}
 
 	for _, taskID := range ids {
-		resp, err := cli.CancelTask(context.Background(), &tes.CancelTaskRequest{Id: taskID})
+		result, err := cli.CancelTask(context.Background(), &tes.CancelTaskRequest{Id: taskID})
 		if err != nil {
 			return err
 		}
-		// CancelTaskResponse is an empty struct
-		out := cli.Marshaler.Format(resp)
-		res = append(res, out)
+
+		// If there's an informational message, print it as JSON
+		if result.Message != "" {
+			output := map[string]interface{}{
+				"message": result.Message,
+			}
+			jsonBytes, _ := json.Marshal(output)
+			res = append(res, string(jsonBytes))
+		} else {
+			// Normal empty response
+			out := cli.Marshaler.Format(result.Response)
+			res = append(res, out)
+		}
 	}
 
 	for _, x := range res {

--- a/cmd/task/cancel.go
+++ b/cmd/task/cancel.go
@@ -20,7 +20,7 @@ func Cancel(server string, ids []string, writer io.Writer) error {
 	res := []string{}
 
 	for _, taskID := range ids {
-		result, err := cli.CancelTask(context.Background(), &tes.CancelTaskRequest{Id: taskID})
+		result, err := cli.CancelTaskWithMessage(context.Background(), &tes.CancelTaskRequest{Id: taskID})
 		if err != nil {
 			return err
 		}

--- a/database/postgres/events.go
+++ b/database/postgres/events.go
@@ -87,8 +87,11 @@ func (db *Postgres) WriteEvent(ctx context.Context, req *events.Event) error {
 			// Validate state transition
 			to := req.GetState()
 			if err = tes.ValidateTransition(state, to); err != nil {
-				logger.Debug("postgres:", err.Error())
-				return status.Error(codes.InvalidArgument, err.Error())
+				logger.Info("postgres: ignoring transition request for task in terminal state",
+					"taskId", req.Id,
+					"currentState", state,
+					"requestedState", to)
+				return nil // No-op on invalid transition)
 			}
 
 			newVersion := time.Now().UnixNano()

--- a/database/postgres/events.go
+++ b/database/postgres/events.go
@@ -87,11 +87,14 @@ func (db *Postgres) WriteEvent(ctx context.Context, req *events.Event) error {
 			// Validate state transition
 			to := req.GetState()
 			if err = tes.ValidateTransition(state, to); err != nil {
-				logger.Info("postgres: ignoring transition request for task in terminal state",
-					"taskId", req.Id,
-					"currentState", state,
-					"requestedState", to)
-				return nil // No-op on invalid transition)
+				if tes.TerminalState(state) {
+					logger.Info("postgres: ignoring transition request for task in terminal state",
+						"taskId", req.Id,
+						"currentState", state,
+						"requestedState", to)
+					return nil // No-op on transition from terminal state
+				}
+				return err
 			}
 
 			newVersion := time.Now().UnixNano()

--- a/server/server.go
+++ b/server/server.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -163,7 +165,9 @@ func (s *Server) Serve(pctx context.Context) error {
 
 	marsh := NewMarshaler()
 	grpcMux := runtime.NewServeMux(
-		runtime.WithMarshalerOption(runtime.MIMEWildcard, marsh), runtime.WithErrorHandler(customErrorHandler))
+		runtime.WithMarshalerOption(runtime.MIMEWildcard, marsh),
+		runtime.WithErrorHandler(customErrorHandler),
+	)
 
 	// m := protojson.MarshalOptions{
 	// 	Indent:          "  ",
@@ -200,7 +204,7 @@ func (s *Server) Serve(pctx context.Context) error {
 
 		// Pass header to plugin if plugin is enabled
 		if s.Plugins != nil {
-			s.addHeadertoCtx(req)
+			req = s.addHeadertoCtx(req)
 		}
 		// TODO this doesnt handle all routes
 		if s.OidcAuth != nil && s.OidcAuth.ServiceConfigURL == "" && len(s.BasicAuth) > 0 {
@@ -218,7 +222,8 @@ func (s *Server) Serve(pctx context.Context) error {
 				resp.Header().Set("Cache-Control", "no-store")
 			}
 
-			grpcMux.ServeHTTP(resp, req)
+			// Apply message middleware to grpcMux
+			messageHandler(grpcMux).ServeHTTP(resp, req)
 		}
 	})
 
@@ -319,4 +324,37 @@ func negotiate(req *http.Request) string {
 	default:
 		return "json"
 	}
+}
+
+// Wrap the grpcMux with middleware that intercepts responses with custom messages
+func messageHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Create a response recorder to capture the response
+		rec := httptest.NewRecorder()
+		next.ServeHTTP(rec, r)
+
+		// Check for the message header in ANY response
+		if msg := rec.Header().Get("Grpc-Metadata-X-Funnel-Message"); msg != "" {
+			// Write the message as JSON
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Cache-Control", rec.Header().Get("Cache-Control"))
+			for k, v := range rec.Header() {
+				// Copy headers except the gRPC metadata one
+				if !strings.HasPrefix(k, "Grpc-Metadata-") {
+					w.Header()[k] = v
+				}
+			}
+			w.WriteHeader(rec.Code)
+			response := map[string]string{"message": msg}
+			json.NewEncoder(w).Encode(response)
+			return // Important: return here to prevent writing the original response
+		}
+
+		// No message - copy the original response as-is
+		for k, v := range rec.Header() {
+			w.Header()[k] = v
+		}
+		w.WriteHeader(rec.Code)
+		w.Write(rec.Body.Bytes())
+	})
 }

--- a/server/tes.go
+++ b/server/tes.go
@@ -222,8 +222,9 @@ func (ts *TaskService) CancelTask(ctx context.Context, req *tes.CancelTaskReques
 
 		// Return success with informational message via metadata
 		msg := fmt.Sprintf("Task is already in %s state, no action needed", task.State)
-		grpc.SetHeader(ctx, metadata.Pairs("X-Funnel-Message", msg))
-
+		if err := grpc.SetHeader(ctx, metadata.Pairs("X-Funnel-Message", msg)); err != nil {
+			ts.Log.Error("Failed to set gRPC header", "error", err)
+		}
 		return result, nil
 	}
 

--- a/server/tes.go
+++ b/server/tes.go
@@ -18,6 +18,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+
+	"google.golang.org/grpc"
 )
 
 // TaskService is a wrapper which handles common TES Task Service operations,
@@ -202,8 +204,31 @@ func (ts *TaskService) CancelTask(ctx context.Context, req *tes.CancelTaskReques
 		ctx = context.WithValue(ctx, "pluginResponse", pluginResponse)
 	}
 
+	// Get current task state to check if it's already terminal
+	task, err := ts.Read.GetTask(ctx, &tes.GetTaskRequest{
+		Id: req.Id,
+	})
+	if err == tes.ErrNotFound {
+		return result, status.Errorf(codes.NotFound, "%v: taskID: %s", err.Error(), req.Id)
+	} else if err != nil {
+		return result, err
+	}
+
+	// Check if task is already in a terminal state
+	if tes.TerminalState(task.State) {
+		ts.Log.Info("Task already in terminal state, skipping cancel",
+			"taskId", req.Id,
+			"state", task.State)
+
+		// Return success with informational message via metadata
+		msg := fmt.Sprintf("Task is already in %s state, no action needed", task.State)
+		grpc.SetHeader(ctx, metadata.Pairs("X-Funnel-Message", msg))
+
+		return result, nil
+	}
+
 	// updated database and other event streams (includes access-checking)
-	err := ts.Event.WriteEvent(ctx, events.NewState(req.Id, tes.Canceled))
+	err = ts.Event.WriteEvent(ctx, events.NewState(req.Id, tes.Canceled))
 	if err == tes.ErrNotFound {
 		return result, status.Errorf(codes.NotFound, "%v: taskID: %s", err.Error(), req.Id)
 	} else if err == tes.ErrNotPermitted {

--- a/tes/client.go
+++ b/tes/client.go
@@ -143,14 +143,28 @@ func (c *Client) CreateTask(ctx context.Context, task *Task) (*CreateTaskRespons
 	return resp, nil
 }
 
+// CancelTaskResult wraps the response with optional metadata
+type CancelTaskResult struct {
+	Response *CancelTaskResponse
+	Message  string // Informational message from server
+}
+
 // CancelTask POSTs to /v1/tasks/{id}:cancel
-func (c *Client) CancelTask(ctx context.Context, req *CancelTaskRequest) (*CancelTaskResponse, error) {
+func (c *Client) CancelTask(ctx context.Context, req *CancelTaskRequest) (*CancelTaskResult, error) {
 	u := c.address + "/v1/tasks/" + req.Id + ":cancel"
 	hreq, _ := http.NewRequest("POST", u, nil)
 	hreq.WithContext(ctx)
 	hreq.Header.Add("Content-Type", "application/json")
 	hreq.SetBasicAuth(c.User, c.Password)
-	body, err := util.CheckHTTPResponse(c.client.Do(hreq))
+
+	// Execute request and capture response
+	httpResp, err := c.client.Do(hreq)
+	if err != nil {
+		return nil, err
+	}
+	defer httpResp.Body.Close()
+
+	body, err := util.CheckHTTPResponse(httpResp, err)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +175,14 @@ func (c *Client) CancelTask(ctx context.Context, req *CancelTaskRequest) (*Cance
 	if err != nil {
 		return nil, err
 	}
-	return resp, nil
+
+	// Check for informational message in HTTP header
+	result := &CancelTaskResult{
+		Response: resp,
+		Message:  httpResp.Header.Get("Grpc-Metadata-X-Funnel-Message"),
+	}
+
+	return result, nil
 }
 
 // GetServiceInfo returns result of GET /v1/service-info

--- a/tes/client.go
+++ b/tes/client.go
@@ -2,6 +2,7 @@ package tes
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -169,20 +170,32 @@ func (c *Client) CancelTask(ctx context.Context, req *CancelTaskRequest) (*Cance
 		return nil, err
 	}
 
-	// Parse response
+	// Check if the response contains a message field (from middleware)
+	var rawResponse map[string]interface{}
+	if err := json.Unmarshal(body, &rawResponse); err == nil {
+		if msg, ok := rawResponse["message"].(string); ok {
+			// This is a message response, not a protobuf response
+			return &CancelTaskResult{
+				Response: &CancelTaskResponse{},
+				Message:  msg,
+			}, nil
+		}
+	}
+
+	// Parse as normal protobuf response
 	resp := &CancelTaskResponse{}
 	err = protojson.Unmarshal(body, resp)
 	if err != nil {
 		return nil, err
 	}
 
-	// Check for informational message in HTTP header
-	result := &CancelTaskResult{
-		Response: resp,
-		Message:  httpResp.Header.Get("Grpc-Metadata-X-Funnel-Message"),
-	}
+	// Check for message in header (fallback for direct gRPC)
+	message := httpResp.Header.Get("Grpc-Metadata-X-Funnel-Message")
 
-	return result, nil
+	return &CancelTaskResult{
+		Response: resp,
+		Message:  message,
+	}, nil
 }
 
 // GetServiceInfo returns result of GET /v1/service-info

--- a/tes/client.go
+++ b/tes/client.go
@@ -61,7 +61,7 @@ func (c *Client) GetTask(ctx context.Context, req *GetTaskRequest) (*Task, error
 	// Send request
 	u := c.address + "/v1/tasks/" + req.Id + "?view=" + req.View
 	hreq, _ := http.NewRequest("GET", u, nil)
-	hreq.WithContext(ctx)
+	hreq = hreq.WithContext(ctx)
 	hreq.SetBasicAuth(c.User, c.Password)
 	body, err := util.CheckHTTPResponse(c.client.Do(hreq))
 	if err != nil {
@@ -97,7 +97,7 @@ func (c *Client) ListTasks(ctx context.Context, req *ListTasksRequest) (*ListTas
 	// Send request
 	u := c.address + "/v1/tasks?" + v.Encode()
 	hreq, _ := http.NewRequest("GET", u, nil)
-	hreq.WithContext(ctx)
+	hreq = hreq.WithContext(ctx)
 	hreq.SetBasicAuth(c.User, c.Password)
 	body, err := util.CheckHTTPResponse(c.client.Do(hreq))
 	if err != nil {
@@ -127,7 +127,7 @@ func (c *Client) CreateTask(ctx context.Context, task *Task) (*CreateTaskRespons
 	// Send request
 	u := c.address + "/v1/tasks"
 	hreq, _ := http.NewRequest("POST", u, bytes.NewReader(b))
-	// hreq.WithContext(ctx)
+	hreq = hreq.WithContext(ctx)
 	hreq.Header.Add("Content-Type", "application/json")
 	hreq.SetBasicAuth(c.User, c.Password)
 	body, err := util.CheckHTTPResponse(c.client.Do(hreq))
@@ -144,17 +144,26 @@ func (c *Client) CreateTask(ctx context.Context, task *Task) (*CreateTaskRespons
 	return resp, nil
 }
 
+// CancelTask POSTs to /v1/tasks/{id}:cancel
+func (c *Client) CancelTask(ctx context.Context, req *CancelTaskRequest) (*CancelTaskResponse, error) {
+	result, err := c.CancelTaskWithMessage(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return result.Response, nil
+}
+
 // CancelTaskResult wraps the response with optional metadata
 type CancelTaskResult struct {
 	Response *CancelTaskResponse
 	Message  string // Informational message from server
 }
 
-// CancelTask POSTs to /v1/tasks/{id}:cancel
-func (c *Client) CancelTask(ctx context.Context, req *CancelTaskRequest) (*CancelTaskResult, error) {
+// CancelTaskWithMessage POSTs to /v1/tasks/{id}:cancel and returns any informational message
+func (c *Client) CancelTaskWithMessage(ctx context.Context, req *CancelTaskRequest) (*CancelTaskResult, error) {
 	u := c.address + "/v1/tasks/" + req.Id + ":cancel"
 	hreq, _ := http.NewRequest("POST", u, nil)
-	hreq.WithContext(ctx)
+	hreq = hreq.WithContext(ctx)
 	hreq.Header.Add("Content-Type", "application/json")
 	hreq.SetBasicAuth(c.User, c.Password)
 
@@ -202,7 +211,7 @@ func (c *Client) CancelTask(ctx context.Context, req *CancelTaskRequest) (*Cance
 func (c *Client) GetServiceInfo(ctx context.Context, req *GetServiceInfoRequest) (*ServiceInfo, error) {
 	u := c.address + "/v1/service-info"
 	hreq, _ := http.NewRequest("GET", u, nil)
-	hreq.WithContext(ctx)
+	hreq = hreq.WithContext(ctx)
 	hreq.SetBasicAuth(c.User, c.Password)
 	body, err := util.CheckHTTPResponse(c.client.Do(hreq))
 	if err != nil {


### PR DESCRIPTION
# Overview 🌀

This PR updates Funnel's response code from `400` (PR #1334) to `200` when a terminal state task attempts to be canceled.

## Old Behavior ⚠️

```sh
➜ curl -i -X POST localhost:8000/v1/tasks/<TASK ID>:cancel
HTTP/1.1 400 Bad Request
{
  "error": "invalid state transition from COMPLETE to CANCELED"
}
```

## New Behavior ✅

```sh
➜ curl -i -X POST localhost:8000/v1/tasks/<TASK ID>:cancel
HTTP/1.1 200 OK
{
  "message": "Task is already in COMPLETE state, no action needed"
}
```