### PR TITLE
fix: Add plugin response (`params` field) to safe/redacted config

### DIFF
--- a/config/safe.go
+++ b/config/safe.go
@@ -93,9 +93,6 @@ func (c *Config) Safe() *Config {
 
 	if safe.Plugins != nil && safe.Plugins.Params != nil {
 		for i, param := range safe.Plugins.Params {
-			if param == "" {
-				continue
-			}
 			safe.Plugins.Params[i] = redact(param)
 		}
 	}

--- a/config/safe.go
+++ b/config/safe.go
@@ -8,64 +8,62 @@ func (c *Config) Safe() *Config {
 		return nil
 	}
 
-	cloned := proto.Clone(c)
-	safe, ok := cloned.(*Config)
+	safe, ok := proto.Clone(c).(*Config)
 	if !ok {
-		// Fallback: if cloning fails for some unexpected reason, avoid redacting the live config.
 		copy := *c
 		safe = &copy
 	}
 
 	// Database credentials
 	if safe.MongoDB != nil {
-		m := *safe.MongoDB
+		m := proto.Clone(safe.MongoDB).(*MongoDB)
 		m.Password = redact(m.Password)
-		safe.MongoDB = &m
+		safe.MongoDB = m
 	}
 
 	if safe.Postgres != nil {
-		p := *safe.Postgres
+		p := proto.Clone(safe.Postgres).(*Postgres)
 		p.User = redact(p.User)
 		p.Password = redact(p.Password)
 		p.AdminUser = redact(p.AdminUser)
 		p.AdminPassword = redact(p.AdminPassword)
-		safe.Postgres = &p
+		safe.Postgres = p
 	}
 
 	if safe.Elastic != nil {
-		e := *safe.Elastic
+		e := proto.Clone(safe.Elastic).(*Elastic)
 		e.Password = redact(e.Password)
 		e.APIKey = redact(e.APIKey)
 		e.ServiceToken = redact(e.ServiceToken)
-		safe.Elastic = &e
+		safe.Elastic = e
 	}
 
 	// Cloud provider credentials
 	if safe.AWSBatch != nil && safe.AWSBatch.AWSConfig != nil {
-		ab := *safe.AWSBatch
-		ac := *ab.AWSConfig
+		ab := proto.Clone(safe.AWSBatch).(*AWSBatch)
+		ac := proto.Clone(ab.AWSConfig).(*AWSConfig)
 		ac.Key = redact(ac.Key)
 		ac.Secret = redact(ac.Secret)
-		ab.AWSConfig = &ac
-		safe.AWSBatch = &ab
+		ab.AWSConfig = ac
+		safe.AWSBatch = ab
 	}
 
 	if safe.DynamoDB != nil && safe.DynamoDB.AWSConfig != nil {
-		d := *safe.DynamoDB
-		ac := *d.AWSConfig
+		d := proto.Clone(safe.DynamoDB).(*DynamoDB)
+		ac := proto.Clone(d.AWSConfig).(*AWSConfig)
 		ac.Key = redact(ac.Key)
 		ac.Secret = redact(ac.Secret)
-		d.AWSConfig = &ac
-		safe.DynamoDB = &d
+		d.AWSConfig = ac
+		safe.DynamoDB = d
 	}
 
 	if safe.AmazonS3 != nil && safe.AmazonS3.AWSConfig != nil {
-		s3 := *safe.AmazonS3
-		ac := *s3.AWSConfig
+		s3 := proto.Clone(safe.AmazonS3).(*AmazonS3Storage)
+		ac := proto.Clone(s3.AWSConfig).(*AWSConfig)
 		ac.Key = redact(ac.Key)
 		ac.Secret = redact(ac.Secret)
-		s3.AWSConfig = &ac
-		safe.AmazonS3 = &s3
+		s3.AWSConfig = ac
+		safe.AmazonS3 = s3
 	}
 
 	if safe.GenericS3 != nil {
@@ -73,74 +71,83 @@ func (c *Config) Safe() *Config {
 			if s3 == nil {
 				continue
 			}
-			gs3 := *s3
+			gs3 := proto.Clone(s3).(*GenericS3Storage)
 			gs3.Key = redact(gs3.Key)
 			gs3.Secret = redact(gs3.Secret)
-			safe.GenericS3[i] = &gs3
+			safe.GenericS3[i] = gs3
 		}
 	}
 
 	if safe.PubSub != nil {
-		ps := *safe.PubSub
+		ps := proto.Clone(safe.PubSub).(*PubSub)
 		ps.CredentialsFile = redact(ps.CredentialsFile)
-		safe.PubSub = &ps
+		safe.PubSub = ps
 	}
 
 	if safe.Datastore != nil {
-		ds := *safe.Datastore
+		ds := proto.Clone(safe.Datastore).(*Datastore)
 		ds.CredentialsFile = redact(ds.CredentialsFile)
-		safe.Datastore = &ds
+		safe.Datastore = ds
 	}
 
 	if safe.GoogleStorage != nil {
-		gs := *safe.GoogleStorage
+		gs := proto.Clone(safe.GoogleStorage).(*GoogleCloudStorage)
 		gs.CredentialsFile = redact(gs.CredentialsFile)
-		safe.GoogleStorage = &gs
+		safe.GoogleStorage = gs
 	}
 
 	// Auth credentials
 	if safe.Server != nil {
-		s := *safe.Server
+		s := proto.Clone(safe.Server).(*Server)
 
 		if s.BasicAuth != nil {
 			for i, cred := range s.BasicAuth {
 				if cred == nil {
 					continue
 				}
-				bc := *cred
+				bc := proto.Clone(cred).(*BasicCredential)
 				bc.Password = redact(bc.Password)
-				s.BasicAuth[i] = &bc
+				s.BasicAuth[i] = bc
 			}
 		}
 
 		if s.OidcAuth != nil {
-			oa := *s.OidcAuth
+			oa := proto.Clone(s.OidcAuth).(*OidcAuth)
 			oa.ClientSecret = redact(oa.ClientSecret)
-			s.OidcAuth = &oa
+			s.OidcAuth = oa
 		}
 
-		safe.Server = &s
+		safe.Server = s
 	}
 
 	if safe.RPCClient != nil && safe.RPCClient.Credential != nil {
-		rpc := *safe.RPCClient
-		cred := *rpc.Credential
+		rpc := proto.Clone(safe.RPCClient).(*RPCClient)
+		cred := proto.Clone(rpc.Credential).(*BasicCredential)
 		cred.Password = redact(cred.Password)
-		rpc.Credential = &cred
-		safe.RPCClient = &rpc
+		rpc.Credential = cred
+		safe.RPCClient = rpc
 	}
 
 	// Storage credentials
 	if safe.Swift != nil {
-		sw := *safe.Swift
+		sw := proto.Clone(safe.Swift).(*SwiftStorage)
 		sw.Password = redact(sw.Password)
-		safe.Swift = &sw
+		safe.Swift = sw
 	}
 
 	if safe.FTPStorage != nil {
-		ftp := *safe.FTPStorage
+		ftp := proto.Clone(safe.FTPStorage).(*FTPStorage)
 		ftp.Password = redact(ftp.Password)
-		safe.FTPStorage = &ftp
+		safe.FTPStorage = ftp
+	}
+
+	if safe.Plugins != nil && safe.Plugins.Params != nil {
+		for i, param := range safe.Plugins.Params {
+			if param == "" {
+				continue
+			}
+			safe.Plugins.Params[i] = redact(param)
+		}
 	}
 
 	return safe

--- a/config/safe.go
+++ b/config/safe.go
@@ -92,8 +92,8 @@ func (c *Config) Safe() *Config {
 	}
 
 	if safe.Plugins != nil && safe.Plugins.Params != nil {
-		for i, param := range safe.Plugins.Params {
-			safe.Plugins.Params[i] = redact(param)
+		for key, param := range safe.Plugins.Params {
+			safe.Plugins.Params[key] = redact(param)
 		}
 	}
 

--- a/config/safe.go
+++ b/config/safe.go
@@ -8,137 +8,87 @@ func (c *Config) Safe() *Config {
 		return nil
 	}
 
-	safe, ok := proto.Clone(c).(*Config)
-	if !ok {
-		copy := *c
-		safe = &copy
-	}
+	safe := proto.Clone(c).(*Config)
 
 	// Database credentials
 	if safe.MongoDB != nil {
-		m := proto.Clone(safe.MongoDB).(*MongoDB)
-		m.Password = redact(m.Password)
-		safe.MongoDB = m
+		safe.MongoDB.Password = redact(safe.MongoDB.Password)
 	}
 
 	if safe.Postgres != nil {
-		p := proto.Clone(safe.Postgres).(*Postgres)
-		p.User = redact(p.User)
-		p.Password = redact(p.Password)
-		p.AdminUser = redact(p.AdminUser)
-		p.AdminPassword = redact(p.AdminPassword)
-		safe.Postgres = p
+		safe.Postgres.User = redact(safe.Postgres.User)
+		safe.Postgres.Password = redact(safe.Postgres.Password)
+		safe.Postgres.AdminUser = redact(safe.Postgres.AdminUser)
+		safe.Postgres.AdminPassword = redact(safe.Postgres.AdminPassword)
 	}
 
 	if safe.Elastic != nil {
-		e := proto.Clone(safe.Elastic).(*Elastic)
-		e.Password = redact(e.Password)
-		e.APIKey = redact(e.APIKey)
-		e.ServiceToken = redact(e.ServiceToken)
-		safe.Elastic = e
+		safe.Elastic.Password = redact(safe.Elastic.Password)
+		safe.Elastic.APIKey = redact(safe.Elastic.APIKey)
+		safe.Elastic.ServiceToken = redact(safe.Elastic.ServiceToken)
 	}
 
 	// Cloud provider credentials
 	if safe.AWSBatch != nil && safe.AWSBatch.AWSConfig != nil {
-		ab := proto.Clone(safe.AWSBatch).(*AWSBatch)
-		ac := proto.Clone(ab.AWSConfig).(*AWSConfig)
-		ac.Key = redact(ac.Key)
-		ac.Secret = redact(ac.Secret)
-		ab.AWSConfig = ac
-		safe.AWSBatch = ab
+		safe.AWSBatch.AWSConfig.Key = redact(safe.AWSBatch.AWSConfig.Key)
+		safe.AWSBatch.AWSConfig.Secret = redact(safe.AWSBatch.AWSConfig.Secret)
 	}
 
 	if safe.DynamoDB != nil && safe.DynamoDB.AWSConfig != nil {
-		d := proto.Clone(safe.DynamoDB).(*DynamoDB)
-		ac := proto.Clone(d.AWSConfig).(*AWSConfig)
-		ac.Key = redact(ac.Key)
-		ac.Secret = redact(ac.Secret)
-		d.AWSConfig = ac
-		safe.DynamoDB = d
+		safe.DynamoDB.AWSConfig.Key = redact(safe.DynamoDB.AWSConfig.Key)
+		safe.DynamoDB.AWSConfig.Secret = redact(safe.DynamoDB.AWSConfig.Secret)
 	}
 
 	if safe.AmazonS3 != nil && safe.AmazonS3.AWSConfig != nil {
-		s3 := proto.Clone(safe.AmazonS3).(*AmazonS3Storage)
-		ac := proto.Clone(s3.AWSConfig).(*AWSConfig)
-		ac.Key = redact(ac.Key)
-		ac.Secret = redact(ac.Secret)
-		s3.AWSConfig = ac
-		safe.AmazonS3 = s3
+		safe.AmazonS3.AWSConfig.Key = redact(safe.AmazonS3.AWSConfig.Key)
+		safe.AmazonS3.AWSConfig.Secret = redact(safe.AmazonS3.AWSConfig.Secret)
 	}
 
-	if safe.GenericS3 != nil {
-		for i, s3 := range safe.GenericS3 {
-			if s3 == nil {
-				continue
-			}
-			gs3 := proto.Clone(s3).(*GenericS3Storage)
-			gs3.Key = redact(gs3.Key)
-			gs3.Secret = redact(gs3.Secret)
-			safe.GenericS3[i] = gs3
+	for _, s3 := range safe.GenericS3 {
+		if s3 == nil {
+			continue
 		}
+		s3.Key = redact(s3.Key)
+		s3.Secret = redact(s3.Secret)
 	}
 
 	if safe.PubSub != nil {
-		ps := proto.Clone(safe.PubSub).(*PubSub)
-		ps.CredentialsFile = redact(ps.CredentialsFile)
-		safe.PubSub = ps
+		safe.PubSub.CredentialsFile = redact(safe.PubSub.CredentialsFile)
 	}
 
 	if safe.Datastore != nil {
-		ds := proto.Clone(safe.Datastore).(*Datastore)
-		ds.CredentialsFile = redact(ds.CredentialsFile)
-		safe.Datastore = ds
+		safe.Datastore.CredentialsFile = redact(safe.Datastore.CredentialsFile)
 	}
 
 	if safe.GoogleStorage != nil {
-		gs := proto.Clone(safe.GoogleStorage).(*GoogleCloudStorage)
-		gs.CredentialsFile = redact(gs.CredentialsFile)
-		safe.GoogleStorage = gs
+		safe.GoogleStorage.CredentialsFile = redact(safe.GoogleStorage.CredentialsFile)
 	}
 
 	// Auth credentials
 	if safe.Server != nil {
-		s := proto.Clone(safe.Server).(*Server)
-
-		if s.BasicAuth != nil {
-			for i, cred := range s.BasicAuth {
-				if cred == nil {
-					continue
-				}
-				bc := proto.Clone(cred).(*BasicCredential)
-				bc.Password = redact(bc.Password)
-				s.BasicAuth[i] = bc
+		for _, cred := range safe.Server.BasicAuth {
+			if cred == nil {
+				continue
 			}
+			cred.Password = redact(cred.Password)
 		}
 
-		if s.OidcAuth != nil {
-			oa := proto.Clone(s.OidcAuth).(*OidcAuth)
-			oa.ClientSecret = redact(oa.ClientSecret)
-			s.OidcAuth = oa
+		if safe.Server.OidcAuth != nil {
+			safe.Server.OidcAuth.ClientSecret = redact(safe.Server.OidcAuth.ClientSecret)
 		}
-
-		safe.Server = s
 	}
 
 	if safe.RPCClient != nil && safe.RPCClient.Credential != nil {
-		rpc := proto.Clone(safe.RPCClient).(*RPCClient)
-		cred := proto.Clone(rpc.Credential).(*BasicCredential)
-		cred.Password = redact(cred.Password)
-		rpc.Credential = cred
-		safe.RPCClient = rpc
+		safe.RPCClient.Credential.Password = redact(safe.RPCClient.Credential.Password)
 	}
 
 	// Storage credentials
 	if safe.Swift != nil {
-		sw := proto.Clone(safe.Swift).(*SwiftStorage)
-		sw.Password = redact(sw.Password)
-		safe.Swift = sw
+		safe.Swift.Password = redact(safe.Swift.Password)
 	}
 
 	if safe.FTPStorage != nil {
-		ftp := proto.Clone(safe.FTPStorage).(*FTPStorage)
-		ftp.Password = redact(ftp.Password)
-		safe.FTPStorage = ftp
+		safe.FTPStorage.Password = redact(safe.FTPStorage.Password)
 	}
 
 	if safe.Plugins != nil && safe.Plugins.Params != nil {

--- a/config/safe_test.go
+++ b/config/safe_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-const redacted = "***"
+var redacted = redact("example")
 
 // TestSafeNilConfig verifies that Safe() on a nil config returns nil.
 func TestSafeNilConfig(t *testing.T) {

--- a/config/safe_test.go
+++ b/config/safe_test.go
@@ -1,0 +1,475 @@
+package config
+
+import (
+	"testing"
+)
+
+const redacted = "***"
+
+// TestSafeNilConfig verifies that Safe() on a nil config returns nil.
+func TestSafeNilConfig(t *testing.T) {
+	var c *Config
+	if c.Safe() != nil {
+		t.Fatal("expected nil for nil config")
+	}
+}
+
+// TestSafeEmptyConfig verifies that Safe() on an empty config does not panic.
+func TestSafeEmptyConfig(t *testing.T) {
+	c := &Config{}
+	safe := c.Safe()
+	if safe == nil {
+		t.Fatal("expected non-nil safe config")
+	}
+}
+
+// TestSafeDoesNotMutateOriginal verifies that Safe() returns a copy and
+// does not modify any fields on the original config.
+func TestSafeDoesNotMutateOriginal(t *testing.T) {
+	c := &Config{
+		MongoDB: &MongoDB{Password: "mongopass"},
+		Postgres: &Postgres{
+			User: "pguser", Password: "pgpass",
+			AdminUser: "pgadmin", AdminPassword: "pgadminpass",
+		},
+		Elastic: &Elastic{Password: "espass", APIKey: "eskey", ServiceToken: "estoken"},
+		AWSBatch: &AWSBatch{
+			AWSConfig: &AWSConfig{Key: "batchkey", Secret: "batchsecret"},
+		},
+		Swift:      &SwiftStorage{Password: "swiftpass"},
+		FTPStorage: &FTPStorage{Password: "ftppass"},
+		Server: &Server{
+			BasicAuth: []*BasicCredential{{User: "user", Password: "basicpass"}},
+			OidcAuth:  &OidcAuth{ClientSecret: "oidcsecret"},
+		},
+		RPCClient: &RPCClient{Credential: &BasicCredential{Password: "rpcpass"}},
+		Plugins:   &Plugins{Params: map[string]string{"key": "pluginparam"}},
+	}
+
+	_ = c.Safe()
+
+	if c.MongoDB.Password != "mongopass" {
+		t.Error("original MongoDB.Password was mutated")
+	}
+	if c.Postgres.Password != "pgpass" {
+		t.Error("original Postgres.Password was mutated")
+	}
+	if c.Elastic.Password != "espass" {
+		t.Error("original Elastic.Password was mutated")
+	}
+	if c.AWSBatch.AWSConfig.Secret != "batchsecret" {
+		t.Error("original AWSBatch.AWSConfig.Secret was mutated")
+	}
+	if c.Swift.Password != "swiftpass" {
+		t.Error("original Swift.Password was mutated")
+	}
+	if c.FTPStorage.Password != "ftppass" {
+		t.Error("original FTPStorage.Password was mutated")
+	}
+	if c.Server.BasicAuth[0].Password != "basicpass" {
+		t.Error("original Server.BasicAuth[0].Password was mutated")
+	}
+	if c.Server.OidcAuth.ClientSecret != "oidcsecret" {
+		t.Error("original Server.OidcAuth.ClientSecret was mutated")
+	}
+	if c.RPCClient.Credential.Password != "rpcpass" {
+		t.Error("original RPCClient.Credential.Password was mutated")
+	}
+	if c.Plugins.Params["key"] != "pluginparam" {
+		t.Error("original Plugins.Params was mutated")
+	}
+}
+
+// TestSafeMongoDBRedaction verifies MongoDB password redaction.
+func TestSafeMongoDBRedaction(t *testing.T) {
+	c := &Config{
+		MongoDB: &MongoDB{
+			Username: "mongouser",
+			Password: "supersecret",
+		},
+	}
+	safe := c.Safe()
+
+	if safe.MongoDB.Password != redacted {
+		t.Errorf("expected MongoDB.Password to be redacted, got %q", safe.MongoDB.Password)
+	}
+	// Non-sensitive field must be preserved
+	if safe.MongoDB.Username != "mongouser" {
+		t.Errorf("expected MongoDB.Username to be preserved, got %q", safe.MongoDB.Username)
+	}
+}
+
+// TestSafeMongoDBEmptyPassword verifies that an empty MongoDB password stays empty.
+func TestSafeMongoDBEmptyPassword(t *testing.T) {
+	c := &Config{MongoDB: &MongoDB{Password: ""}}
+	safe := c.Safe()
+	if safe.MongoDB.Password != "" {
+		t.Errorf("expected empty MongoDB.Password to stay empty, got %q", safe.MongoDB.Password)
+	}
+}
+
+// TestSafePostgresRedaction verifies all four Postgres credential fields.
+func TestSafePostgresRedaction(t *testing.T) {
+	c := &Config{
+		Postgres: &Postgres{
+			Host:          "pghost",
+			User:          "pguser",
+			Password:      "pgpass",
+			AdminUser:     "pgadmin",
+			AdminPassword: "pgadminpass",
+		},
+	}
+	safe := c.Safe()
+
+	for field, got := range map[string]string{
+		"User":          safe.Postgres.User,
+		"Password":      safe.Postgres.Password,
+		"AdminUser":     safe.Postgres.AdminUser,
+		"AdminPassword": safe.Postgres.AdminPassword,
+	} {
+		if got != redacted {
+			t.Errorf("expected Postgres.%s to be redacted, got %q", field, got)
+		}
+	}
+	if safe.Postgres.Host != "pghost" {
+		t.Errorf("expected Postgres.Host to be preserved, got %q", safe.Postgres.Host)
+	}
+}
+
+// TestSafePostgresEmptyCredentials verifies that empty Postgres credentials stay empty.
+func TestSafePostgresEmptyCredentials(t *testing.T) {
+	c := &Config{
+		Postgres: &Postgres{User: "", Password: "", AdminUser: "", AdminPassword: ""},
+	}
+	safe := c.Safe()
+	if safe.Postgres.User != "" || safe.Postgres.Password != "" ||
+		safe.Postgres.AdminUser != "" || safe.Postgres.AdminPassword != "" {
+		t.Error("expected empty Postgres credentials to stay empty")
+	}
+}
+
+// TestSafeElasticRedaction verifies Password, APIKey, and ServiceToken redaction.
+func TestSafeElasticRedaction(t *testing.T) {
+	c := &Config{
+		Elastic: &Elastic{
+			URL:          "http://elastic:9200",
+			Username:     "esuser",
+			Password:     "espass",
+			APIKey:       "esapikey",
+			ServiceToken: "estoken",
+		},
+	}
+	safe := c.Safe()
+
+	for field, got := range map[string]string{
+		"Password":     safe.Elastic.Password,
+		"APIKey":       safe.Elastic.APIKey,
+		"ServiceToken": safe.Elastic.ServiceToken,
+	} {
+		if got != redacted {
+			t.Errorf("expected Elastic.%s to be redacted, got %q", field, got)
+		}
+	}
+	if safe.Elastic.Username != "esuser" {
+		t.Errorf("expected Elastic.Username to be preserved, got %q", safe.Elastic.Username)
+	}
+}
+
+// TestSafeAWSBatchRedaction verifies AWSBatch Key and Secret redaction.
+func TestSafeAWSBatchRedaction(t *testing.T) {
+	c := &Config{
+		AWSBatch: &AWSBatch{
+			JobDefinition: "my-job-def",
+			AWSConfig: &AWSConfig{
+				Key:    "AKIAIOSFODNN7EXAMPLE",
+				Secret: "wJalrXUtnFEMI/K7MDENG",
+				Region: "us-east-1",
+			},
+		},
+	}
+	safe := c.Safe()
+
+	if safe.AWSBatch.AWSConfig.Key != redacted {
+		t.Errorf("expected AWSBatch.AWSConfig.Key to be redacted, got %q", safe.AWSBatch.AWSConfig.Key)
+	}
+	if safe.AWSBatch.AWSConfig.Secret != redacted {
+		t.Errorf("expected AWSBatch.AWSConfig.Secret to be redacted, got %q", safe.AWSBatch.AWSConfig.Secret)
+	}
+	if safe.AWSBatch.AWSConfig.Region != "us-east-1" {
+		t.Errorf("expected AWSBatch.AWSConfig.Region to be preserved, got %q", safe.AWSBatch.AWSConfig.Region)
+	}
+	if safe.AWSBatch.JobDefinition != "my-job-def" {
+		t.Errorf("expected AWSBatch.JobDefinition to be preserved, got %q", safe.AWSBatch.JobDefinition)
+	}
+}
+
+// TestSafeAWSBatchNilAWSConfig verifies no panic when AWSBatch.AWSConfig is nil.
+func TestSafeAWSBatchNilAWSConfig(t *testing.T) {
+	c := &Config{AWSBatch: &AWSBatch{JobDefinition: "jd"}}
+	safe := c.Safe()
+	if safe.AWSBatch.AWSConfig != nil {
+		t.Errorf("expected AWSBatch.AWSConfig to remain nil")
+	}
+}
+
+// TestSafeDynamoDBRedaction verifies DynamoDB Key and Secret redaction.
+func TestSafeDynamoDBRedaction(t *testing.T) {
+	c := &Config{
+		DynamoDB: &DynamoDB{
+			TableBasename: "funnel",
+			AWSConfig: &AWSConfig{
+				Key:    "dynamo-key",
+				Secret: "dynamo-secret",
+			},
+		},
+	}
+	safe := c.Safe()
+
+	if safe.DynamoDB.AWSConfig.Key != redacted {
+		t.Errorf("expected DynamoDB.AWSConfig.Key to be redacted, got %q", safe.DynamoDB.AWSConfig.Key)
+	}
+	if safe.DynamoDB.AWSConfig.Secret != redacted {
+		t.Errorf("expected DynamoDB.AWSConfig.Secret to be redacted, got %q", safe.DynamoDB.AWSConfig.Secret)
+	}
+}
+
+// TestSafeAmazonS3Redaction verifies AmazonS3 Key and Secret redaction.
+func TestSafeAmazonS3Redaction(t *testing.T) {
+	c := &Config{
+		AmazonS3: &AmazonS3Storage{
+			AWSConfig: &AWSConfig{
+				Key:    "s3-key",
+				Secret: "s3-secret",
+			},
+		},
+	}
+	safe := c.Safe()
+
+	if safe.AmazonS3.AWSConfig.Key != redacted {
+		t.Errorf("expected AmazonS3.AWSConfig.Key to be redacted, got %q", safe.AmazonS3.AWSConfig.Key)
+	}
+	if safe.AmazonS3.AWSConfig.Secret != redacted {
+		t.Errorf("expected AmazonS3.AWSConfig.Secret to be redacted, got %q", safe.AmazonS3.AWSConfig.Secret)
+	}
+}
+
+// TestSafeGenericS3Redaction verifies GenericS3 Key and Secret redaction across multiple entries.
+func TestSafeGenericS3Redaction(t *testing.T) {
+	c := &Config{
+		GenericS3: []*GenericS3Storage{
+			{Endpoint: "https://s3.example.com", Key: "gs3-key", Secret: "gs3-secret"},
+			{Endpoint: "https://s3-2.example.com", Key: "gs3-key2", Secret: "gs3-secret2"},
+		},
+	}
+	safe := c.Safe()
+
+	if safe.GenericS3[0].Key != redacted {
+		t.Errorf("expected GenericS3[0].Key to be redacted, got %q", safe.GenericS3[0].Key)
+	}
+	if safe.GenericS3[0].Secret != redacted {
+		t.Errorf("expected GenericS3[0].Secret to be redacted, got %q", safe.GenericS3[0].Secret)
+	}
+	if safe.GenericS3[0].Endpoint != "https://s3.example.com" {
+		t.Errorf("expected GenericS3[0].Endpoint to be preserved, got %q", safe.GenericS3[0].Endpoint)
+	}
+	if safe.GenericS3[1].Key != redacted {
+		t.Errorf("expected GenericS3[1].Key to be redacted, got %q", safe.GenericS3[1].Key)
+	}
+	if safe.GenericS3[1].Secret != redacted {
+		t.Errorf("expected GenericS3[1].Secret to be redacted, got %q", safe.GenericS3[1].Secret)
+	}
+}
+
+// TestSafePubSubRedaction verifies PubSub CredentialsFile redaction.
+func TestSafePubSubRedaction(t *testing.T) {
+	c := &Config{
+		PubSub: &PubSub{
+			Topic:           "my-topic",
+			CredentialsFile: "/path/to/creds.json",
+		},
+	}
+	safe := c.Safe()
+
+	if safe.PubSub.CredentialsFile != redacted {
+		t.Errorf("expected PubSub.CredentialsFile to be redacted, got %q", safe.PubSub.CredentialsFile)
+	}
+	if safe.PubSub.Topic != "my-topic" {
+		t.Errorf("expected PubSub.Topic to be preserved, got %q", safe.PubSub.Topic)
+	}
+}
+
+// TestSafeDatastoreRedaction verifies Datastore CredentialsFile redaction.
+func TestSafeDatastoreRedaction(t *testing.T) {
+	c := &Config{
+		Datastore: &Datastore{
+			Project:         "my-project",
+			CredentialsFile: "/path/to/creds.json",
+		},
+	}
+	safe := c.Safe()
+
+	if safe.Datastore.CredentialsFile != redacted {
+		t.Errorf("expected Datastore.CredentialsFile to be redacted, got %q", safe.Datastore.CredentialsFile)
+	}
+	if safe.Datastore.Project != "my-project" {
+		t.Errorf("expected Datastore.Project to be preserved, got %q", safe.Datastore.Project)
+	}
+}
+
+// TestSafeGoogleStorageRedaction verifies GoogleStorage CredentialsFile redaction.
+func TestSafeGoogleStorageRedaction(t *testing.T) {
+	c := &Config{
+		GoogleStorage: &GoogleCloudStorage{
+			CredentialsFile: "/path/to/creds.json",
+		},
+	}
+	safe := c.Safe()
+
+	if safe.GoogleStorage.CredentialsFile != redacted {
+		t.Errorf("expected GoogleStorage.CredentialsFile to be redacted, got %q", safe.GoogleStorage.CredentialsFile)
+	}
+}
+
+// TestSafeServerBasicAuthRedaction verifies Server BasicAuth password redaction
+// across multiple entries.
+func TestSafeServerBasicAuthRedaction(t *testing.T) {
+	c := &Config{
+		Server: &Server{
+			BasicAuth: []*BasicCredential{
+				{User: "alice", Password: "alicepass"},
+				{User: "bob", Password: "bobpass"},
+			},
+		},
+	}
+	safe := c.Safe()
+
+	if safe.Server.BasicAuth[0].Password != redacted {
+		t.Errorf("expected Server.BasicAuth[0].Password to be redacted, got %q", safe.Server.BasicAuth[0].Password)
+	}
+	if safe.Server.BasicAuth[0].User != "alice" {
+		t.Errorf("expected Server.BasicAuth[0].User to be preserved, got %q", safe.Server.BasicAuth[0].User)
+	}
+	if safe.Server.BasicAuth[1].Password != redacted {
+		t.Errorf("expected Server.BasicAuth[1].Password to be redacted, got %q", safe.Server.BasicAuth[1].Password)
+	}
+}
+
+// TestSafeServerOidcAuthRedaction verifies OidcAuth ClientSecret redaction.
+func TestSafeServerOidcAuthRedaction(t *testing.T) {
+	c := &Config{
+		Server: &Server{
+			OidcAuth: &OidcAuth{
+				ClientId:     "my-client-id",
+				ClientSecret: "my-client-secret",
+			},
+		},
+	}
+	safe := c.Safe()
+
+	if safe.Server.OidcAuth.ClientSecret != redacted {
+		t.Errorf("expected Server.OidcAuth.ClientSecret to be redacted, got %q", safe.Server.OidcAuth.ClientSecret)
+	}
+	if safe.Server.OidcAuth.ClientId != "my-client-id" {
+		t.Errorf("expected Server.OidcAuth.ClientId to be preserved, got %q", safe.Server.OidcAuth.ClientId)
+	}
+}
+
+// TestSafeRPCClientRedaction verifies RPCClient credential password redaction.
+func TestSafeRPCClientRedaction(t *testing.T) {
+	c := &Config{
+		RPCClient: &RPCClient{
+			ServerAddress: "funnel:9090",
+			Credential:    &BasicCredential{User: "rpcuser", Password: "rpcpass"},
+		},
+	}
+	safe := c.Safe()
+
+	if safe.RPCClient.Credential.Password != redacted {
+		t.Errorf("expected RPCClient.Credential.Password to be redacted, got %q", safe.RPCClient.Credential.Password)
+	}
+	if safe.RPCClient.ServerAddress != "funnel:9090" {
+		t.Errorf("expected RPCClient.ServerAddress to be preserved, got %q", safe.RPCClient.ServerAddress)
+	}
+}
+
+// TestSafeRPCClientNilCredential verifies no panic when RPCClient.Credential is nil.
+func TestSafeRPCClientNilCredential(t *testing.T) {
+	c := &Config{RPCClient: &RPCClient{ServerAddress: "funnel:9090"}}
+	safe := c.Safe()
+	if safe.RPCClient.Credential != nil {
+		t.Error("expected RPCClient.Credential to remain nil")
+	}
+}
+
+// TestSafeSwiftRedaction verifies Swift password redaction.
+func TestSafeSwiftRedaction(t *testing.T) {
+	c := &Config{
+		Swift: &SwiftStorage{
+			UserName: "swiftuser",
+			Password: "swiftpass",
+		},
+	}
+	safe := c.Safe()
+
+	if safe.Swift.Password != redacted {
+		t.Errorf("expected Swift.Password to be redacted, got %q", safe.Swift.Password)
+	}
+	if safe.Swift.UserName != "swiftuser" {
+		t.Errorf("expected Swift.UserName to be preserved, got %q", safe.Swift.UserName)
+	}
+}
+
+// TestSafeFTPStorageRedaction verifies FTPStorage password redaction.
+func TestSafeFTPStorageRedaction(t *testing.T) {
+	c := &Config{
+		FTPStorage: &FTPStorage{
+			User:     "ftpuser",
+			Password: "ftppass",
+		},
+	}
+	safe := c.Safe()
+
+	if safe.FTPStorage.Password != redacted {
+		t.Errorf("expected FTPStorage.Password to be redacted, got %q", safe.FTPStorage.Password)
+	}
+	if safe.FTPStorage.User != "ftpuser" {
+		t.Errorf("expected FTPStorage.User to be preserved, got %q", safe.FTPStorage.User)
+	}
+}
+
+// TestSafeNilPlugins verifies that a nil Plugins field does not panic.
+func TestSafeNilPlugins(t *testing.T) {
+	c := &Config{}
+	safe := c.Safe()
+	if safe.Plugins != nil {
+		t.Error("expected Plugins to remain nil")
+	}
+}
+
+// TestSafePluginsParamsRedaction verifies that all Plugins.Params values are redacted.
+func TestSafePluginsParamsRedaction(t *testing.T) {
+	c := &Config{
+		Plugins: &Plugins{
+			Path: "/path/to/plugin",
+			Params: map[string]string{
+				"api_key": "secretkey",
+				"token":   "secrettoken",
+				"empty":   "",
+			},
+		},
+	}
+	safe := c.Safe()
+
+	if safe.Plugins.Params["api_key"] != redacted {
+		t.Errorf("expected Plugins.Params[api_key] to be redacted, got %q", safe.Plugins.Params["api_key"])
+	}
+	if safe.Plugins.Params["token"] != redacted {
+		t.Errorf("expected Plugins.Params[token] to be redacted, got %q", safe.Plugins.Params["token"])
+	}
+	if safe.Plugins.Params["empty"] != "" {
+		t.Errorf("expected empty Plugins.Params[empty] to stay empty, got %q", safe.Plugins.Params["empty"])
+	}
+	if safe.Plugins.Path != "/path/to/plugin" {
+		t.Errorf("expected Plugins.Path to be preserved, got %q", safe.Plugins.Path)
+	}
+}


### PR DESCRIPTION
# Overview 🌀

This PR updates the safe/redacted config with additional fields + unit tests!

# Current Behavior ❌

Plugin response with unredacted fields:

```json
"Plugins":  {
  "Path":  "example-plugin",
  "Params":  {
    "api_key": "example-key",
    "token":   "example-token",
    "empty":   "",
  }
}
```

# New Behavior ✔️

Plugin response with redacted fields:

```json
"Plugins":  {
  "Path":  "example-plugin",
  "Params":  {
    "api_key": "***",
    "token":   "***",
    "empty":   "",
  }
}
```