### PR TITLE
Add support for TES Volumes in Kubernetes

### DIFF
--- a/compute/kubernetes/backend.go
+++ b/compute/kubernetes/backend.go
@@ -178,8 +178,8 @@ func (b *Backend) createResources(ctx context.Context, task *tes.Task, config *c
 		defer cancel()
 	}
 
-	// If the task has inputs or outputs that must be taken care of create a PVC
-	if len(task.Inputs) > 0 || len(task.Outputs) > 0 {
+	// If the task has inputs, outputs, or volumes that must be taken care of create a PVC
+	if len(task.Inputs) > 0 || len(task.Outputs) > 0 || len(task.Volumes) > 0 {
 		b.log.Debug("creating Worker PV", "taskID", task.Id)
 
 		// Check to make sure required configs are present
@@ -275,14 +275,14 @@ func (b *Backend) cleanResources(ctx context.Context, taskId string) error {
 
 	// Delete Job
 	b.log.Debug("deleting Job", "taskID", taskId)
-	err = resources.DeleteJob(ctx, b.conf, taskId, b.client, b.log)
+	err := resources.DeleteJob(ctx, b.conf, taskId, b.client, b.log)
 	if err != nil {
 		errs = multierror.Append(errs, err)
 		b.log.Error("deleting Job", "error", err)
 	}
 
 	// Delete PVC
-	err := resources.DeletePVC(ctx, taskId, b.conf.Kubernetes.JobsNamespace, b.client, b.log)
+	err = resources.DeletePVC(ctx, taskId, b.conf.Kubernetes.JobsNamespace, b.client, b.log)
 	if err != nil {
 		errs = multierror.Append(errs, err)
 		b.log.Error("deleting Worker PVC", "error", err)

--- a/compute/kubernetes/backend.go
+++ b/compute/kubernetes/backend.go
@@ -178,7 +178,8 @@ func (b *Backend) createResources(ctx context.Context, task *tes.Task, config *c
 		defer cancel()
 	}
 
-	// If the task has inputs, outputs, or volumes that must be taken care of create a PVC
+	// If the task has inputs, outputs, or declared volumes, create a PVC so
+	// executor pods can share data via PVC subPath mounts.
 	if len(task.Inputs) > 0 || len(task.Outputs) > 0 || len(task.Volumes) > 0 {
 		b.log.Debug("creating Worker PV", "taskID", task.Id)
 

--- a/compute/kubernetes/resources/job.go
+++ b/compute/kubernetes/resources/job.go
@@ -46,7 +46,7 @@ func CreateJob(ctx context.Context, task *tes.Task, config *config.Config, clien
 		"RamGb":              res.GetRamGb(),
 		"DiskGb":             res.GetDiskGb(),
 		"Image":              pods.Items[0].Spec.Containers[0].Image,
-		"NeedsPVC":           len(task.Inputs) > 0 || len(task.Outputs) > 0,
+		"NeedsPVC":           len(task.Inputs) > 0 || len(task.Outputs) > 0 || len(task.Volumes) > 0,
 		"NodeSelector":       config.Kubernetes.NodeSelector,
 		"Tolerations":        config.Kubernetes.Tolerations,
 		"ServiceAccountName": fmt.Sprintf("funnel-worker-sa-%s-%s", config.Kubernetes.JobsNamespace, task.Id),

--- a/config/kubernetes/executor-job.yaml
+++ b/config/kubernetes/executor-job.yaml
@@ -63,33 +63,15 @@ spec:
             ephemeral-storage: {{.DiskGb}}
 
         volumeMounts:
-        # TES task.volumes — emptyDir mounts shared between executors in this task
-        {{- range $idx, $item := .Volumes}}
-        {{- if $item.Tmp}}
-          - name: tes-vol-{{$idx}}
-            mountPath: {{$item.ContainerPath}}
-        {{- end}}
-        {{- end}}
-        # Input/output volumes — backed by the task PVC
         {{- if .NeedsPVC }}
           {{- range $idx, $item := .Volumes}}
-          {{- if not $item.Tmp}}
           - name: funnel-storage-{{$.TaskId}}
             mountPath: {{$item.ContainerPath}}
             subPath: {{$.TaskId}}{{$item.ContainerPath}}
           {{- end}}
-          {{- end}}
         {{- end }}
 
       volumes:
-      # TES task.volumes — one emptyDir per declared volume path
-      {{- range $idx, $item := .Volumes}}
-      {{- if $item.Tmp}}
-      - name: tes-vol-{{$idx}}
-        emptyDir: {}
-      {{- end}}
-      {{- end}}
-      # Input/output storage — PVC backed by external storage
       {{- if .NeedsPVC }}
       - name: funnel-storage-{{.TaskId}}
         persistentVolumeClaim:

--- a/config/kubernetes/executor-job.yaml
+++ b/config/kubernetes/executor-job.yaml
@@ -63,16 +63,33 @@ spec:
             ephemeral-storage: {{.DiskGb}}
 
         volumeMounts:
-        ### DO NOT CHANGE THIS
+        # TES task.volumes — emptyDir mounts shared between executors in this task
+        {{- range $idx, $item := .Volumes}}
+        {{- if $item.Tmp}}
+          - name: tes-vol-{{$idx}}
+            mountPath: {{$item.ContainerPath}}
+        {{- end}}
+        {{- end}}
+        # Input/output volumes — backed by the task PVC
         {{- if .NeedsPVC }}
-          {{range $idx, $item := .Volumes}}
+          {{- range $idx, $item := .Volumes}}
+          {{- if not $item.Tmp}}
           - name: funnel-storage-{{$.TaskId}}
             mountPath: {{$item.ContainerPath}}
             subPath: {{$.TaskId}}{{$item.ContainerPath}}
-          {{end}}
+          {{- end}}
+          {{- end}}
         {{- end }}
 
       volumes:
+      # TES task.volumes — one emptyDir per declared volume path
+      {{- range $idx, $item := .Volumes}}
+      {{- if $item.Tmp}}
+      - name: tes-vol-{{$idx}}
+        emptyDir: {}
+      {{- end}}
+      {{- end}}
+      # Input/output storage — PVC backed by external storage
       {{- if .NeedsPVC }}
       - name: funnel-storage-{{.TaskId}}
         persistentVolumeClaim:

--- a/worker/file_mapper.go
+++ b/worker/file_mapper.go
@@ -38,10 +38,6 @@ type Volume struct {
 	// The path in Docker.
 	ContainerPath string
 	Readonly      bool
-	// Tmp marks volumes declared in the TES task's `volumes` field (and /tmp).
-	// These are ephemeral scratch volumes shared between executors in the same
-	// task, backed by emptyDir on Kubernetes.
-	Tmp bool
 }
 
 // NewFileMapper returns a new FileMapper, which maps files into the given
@@ -366,15 +362,6 @@ func (mapper *FileMapper) AddTmpVolume(mountPoint string) error {
 	err = mapper.AddVolume(hostPath, mountPoint, false)
 	if err != nil {
 		return err
-	}
-
-	// Mark the volume as Tmp so Kubernetes can back it with an emptyDir
-	// rather than a PVC subpath.
-	for i, v := range mapper.Volumes {
-		if v.ContainerPath == mountPoint {
-			mapper.Volumes[i].Tmp = true
-			break
-		}
 	}
 	return nil
 }

--- a/worker/file_mapper.go
+++ b/worker/file_mapper.go
@@ -38,6 +38,10 @@ type Volume struct {
 	// The path in Docker.
 	ContainerPath string
 	Readonly      bool
+	// Tmp marks volumes declared in the TES task's `volumes` field (and /tmp).
+	// These are ephemeral scratch volumes shared between executors in the same
+	// task, backed by emptyDir on Kubernetes.
+	Tmp bool
 }
 
 // NewFileMapper returns a new FileMapper, which maps files into the given
@@ -362,6 +366,15 @@ func (mapper *FileMapper) AddTmpVolume(mountPoint string) error {
 	err = mapper.AddVolume(hostPath, mountPoint, false)
 	if err != nil {
 		return err
+	}
+
+	// Mark the volume as Tmp so Kubernetes can back it with an emptyDir
+	// rather than a PVC subpath.
+	for i, v := range mapper.Volumes {
+		if v.ContainerPath == mountPoint {
+			mapper.Volumes[i].Tmp = true
+			break
+		}
 	}
 	return nil
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -238,7 +238,7 @@ func (r *DefaultWorker) Run(pctx context.Context) (runerr error) {
 					Resources:      resources,
 					ResourceLimits: resourceLimits,
 					Command:        command,
-					NeedsPVC:       len(task.GetInputs()) > 0 || len(task.GetOutputs()) > 0,
+					NeedsPVC:       len(task.GetInputs()) > 0 || len(task.GetOutputs()) > 0 || len(task.GetVolumes()) > 0,
 					NodeSelector:   r.Executor.NodeSelector,
 					Tolerations:    r.Executor.Tolerations,
 					ServiceAccount: fmt.Sprintf("funnel-worker-sa-%s-%s", r.Executor.JobsNamespace, task.Id),


### PR DESCRIPTION
# Overview 🌀

This PR adds initial support of TES Volumes in Kubernetes.

# Current Behavior ❌

TES Volumes are not supported in the K8s backend (simply lost/not translated to K8s spec)

# New Behavior ✔️

> [!CAUTION]
>
> Still need to update [`executor-job.yaml`](https://github.com/ohsu-comp-bio/helm-charts/blob/main/charts/funnel/files/executor-job.yaml) to support this change...

TES volumes are mounted as an [`emptyDir`](https://kubernetes.io/docs/concepts/storage/volumes/) Volume in the [Executor Job](https://github.com/ohsu-comp-bio/helm-charts/blob/main/charts/funnel/files/executor-job.yaml).