### PR TITLE
fix: Skip ServiceAccount deletion if in use by other pods

### DIFF
--- a/compute/kubernetes/resources/resources_test.go
+++ b/compute/kubernetes/resources/resources_test.go
@@ -276,6 +276,10 @@ func TestDeleteServiceAccount(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "funnel-worker-sa-" + testTaskID,
 			Namespace: namespace,
+			Labels: map[string]string{
+				"app":    "funnel",
+				"taskId": testTaskID,
+			},
 		},
 	}
 	_, err := fakeClient.CoreV1().ServiceAccounts(namespace).Create(context.Background(), sa, metav1.CreateOptions{})
@@ -286,6 +290,49 @@ func TestDeleteServiceAccount(t *testing.T) {
 	err = DeleteServiceAccount(context.Background(), testTaskID, namespace, fakeClient, l)
 	if err != nil {
 		t.Errorf("DeleteServiceAccount failed: %v", err)
+	}
+}
+
+func TestDeleteServiceAccountInUse(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "funnel-worker-sa-" + testTaskID,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app":    "funnel",
+				"taskId": testTaskID,
+			},
+		},
+	}
+	_, err := fakeClient.CoreV1().ServiceAccounts(namespace).Create(context.Background(), sa, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create test ServiceAccount: %v", err)
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: sa.Name,
+		},
+	}
+	_, err = fakeClient.CoreV1().Pods(namespace).Create(context.Background(), pod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create test Pod: %v", err)
+	}
+
+	err = DeleteServiceAccount(context.Background(), testTaskID, namespace, fakeClient, l)
+	if err == nil {
+		t.Fatal("expected DeleteServiceAccount to fail when ServiceAccount is in use")
+	}
+
+	_, err = fakeClient.CoreV1().ServiceAccounts(namespace).Get(context.Background(), sa.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected ServiceAccount to remain after failed delete: %v", err)
 	}
 }
 

--- a/compute/kubernetes/resources/serviceaccount.go
+++ b/compute/kubernetes/resources/serviceaccount.go
@@ -68,6 +68,21 @@ func CreateServiceAccount(ctx context.Context, task *tes.Task, conf *config.Conf
 	return nil
 }
 
+func podsUsingServiceAccount(ctx context.Context, saName, namespace string, client kubernetes.Interface) ([]string, error) {
+	pods, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("listing pods using ServiceAccount %s: %v", saName, err)
+	}
+
+	var podNames []string
+	for _, pod := range pods.Items {
+		if pod.Spec.ServiceAccountName == saName {
+			podNames = append(podNames, pod.Name)
+		}
+	}
+	return podNames, nil
+}
+
 // DeleteServiceAccount deletes the ServiceAccount created for a task.
 func DeleteServiceAccount(ctx context.Context, taskID string, namespace string, client kubernetes.Interface, log *logger.Logger) error {
 	// ServiceAccount names are not available here without config, so we list by label.
@@ -78,6 +93,14 @@ func DeleteServiceAccount(ctx context.Context, taskID string, namespace string, 
 		return fmt.Errorf("listing ServiceAccounts for task %s: %v", taskID, err)
 	}
 	for _, sa := range sas.Items {
+		podNames, err := podsUsingServiceAccount(ctx, sa.Name, namespace, client)
+		if err != nil {
+			return err
+		}
+		if len(podNames) > 0 {
+			return fmt.Errorf("serviceAccount %s is still in use by pod(s): %v", sa.Name, podNames)
+		}
+
 		log.Debug("deleting Worker ServiceAccount", "name", sa.Name, "taskID", taskID)
 		if err := client.CoreV1().ServiceAccounts(namespace).Delete(ctx, sa.Name, metav1.DeleteOptions{}); err != nil {
 			return fmt.Errorf("deleting ServiceAccount %s: %v", sa.Name, err)


### PR DESCRIPTION
# Overview 🌀

This PR updates the `DeleteServiceAccount` function to skip deleting ServiceAccounts if they're in use by any other pods.

This can result in downstream errors for workflows that expect ServcieAccounts to be user-scoped (rather than task-scoped).

## Current Behavior ❌

ServiceAccounts are deleted as soon as it's respective task completes.

## New Behavior ✔️

ServiceAccounts are now deleted as soon as it's respective task completes and it's not assigned to any other pods.

## Next Steps 🛠️

> [!IMPORTANT]
>
> - Verify that this new behavior is in-line with Gen3-Workflow's default behavior (e.g. via [`_WORKER_SA`](https://github.com/search?q=repo%3Auc-cdis%2Fgen3-workflow%20_WORKER_SA&type=code))
> - Add sequence diagram for the new behavior, including:
>   - Task submission
>   - ServiceAccount creation
>   - Task lifecycle
>   - ServiceAccount clean up