### PR TITLE
fix: Revert K8s resource creation `if` check

### DIFF
--- a/compute/kubernetes/backend.go
+++ b/compute/kubernetes/backend.go
@@ -191,68 +191,54 @@ func (b *Backend) createResources(ctx context.Context, task *tes.Task, config *c
 		Controller:         &isController,
 	}
 
-	// Create ConfigMap (only when a template is configured; deployments using a
-	// static shared ConfigMap via the WorkerTemplate volume spec skip this).
-	if config.Kubernetes.ConfigMapTemplate != "" {
-		b.log.Debug("creating Worker ConfigMap", "taskID", task.Id)
-		err = resources.CreateConfigMap(timeoutCtx, task.Id, config, b.client, b.log, ownerRef)
-		if err != nil {
-			_ = b.Cancel(context.Background(), task.Id)
-			return fmt.Errorf("creating Worker ConfigMap: %w", err)
-		}
+	b.log.Debug("creating Worker ConfigMap", "taskID", task.Id)
+	err = resources.CreateConfigMap(timeoutCtx, task.Id, config, b.client, b.log, ownerRef)
+	if err != nil {
+		_ = b.Cancel(context.Background(), task.Id)
+		return fmt.Errorf("creating Worker ConfigMap: %w", err)
 	}
 
-	// Create ServiceAccount, Role, and RoleBinding only when templates are
-	// configured. Deployments that supply a pre-existing shared SA (e.g. via
-	// _WORKER_SA tag or a static Helm-managed SA) skip these steps entirely.
-	// External (user-managed) SAs are not owned by the Job — they outlive tasks.
-	if config.Kubernetes.ServiceAccountTemplate != "" {
-		saName := fmt.Sprintf("funnel-worker-sa-%s-%s", config.Kubernetes.JobsNamespace, task.Id)
-		externalSA := false
-		if sa, exists := task.Tags["_WORKER_SA"]; exists && sa != "" {
-			saName = sa
-			externalSA = true
-		}
-
-		// TODO: Add error handler to handle case where Get fails for reasons other than `NotFound`
-		// e.g. network issues, permission issues, etc.
-		_, err = b.client.CoreV1().ServiceAccounts(config.Kubernetes.JobsNamespace).Get(timeoutCtx, saName, metav1.GetOptions{})
-
-		// ServiceAccount does not exist, create it
-		if err != nil {
-			b.log.Debug("Error getting ServiceAccount:", "ServiceAccount", saName, "taskID", task.Id, "error", err)
-			b.log.Debug("Creating Worker ServiceAccount", "taskID", task.Id)
-			// Only set the owner reference for task-level SAs; external SAs are shared and must not be GC'd with the job.
-			saOwnerRef := ownerRef
-			if externalSA {
-				saOwnerRef = nil
-			}
-			err = resources.CreateServiceAccount(timeoutCtx, task, config, b.client, b.log, saOwnerRef)
-			if err != nil {
-				_ = b.Cancel(context.Background(), task.Id)
-				return fmt.Errorf("creating Worker ServiceAccount: %w", err)
-			}
-		} else {
-			b.log.Debug("ServiceAccount already exists, skipping creation", "ServiceAccount", saName, "taskID", task.Id)
-		}
+	saName := fmt.Sprintf("funnel-worker-sa-%s-%s", config.Kubernetes.JobsNamespace, task.Id)
+	externalSA := false
+	if sa, exists := task.Tags["_WORKER_SA"]; exists && sa != "" {
+		saName = sa
+		externalSA = true
 	}
 
-	if config.Kubernetes.RoleTemplate != "" {
-		b.log.Debug("creating Worker Role", "taskID", task.Id)
-		err = resources.CreateRole(timeoutCtx, task, config, b.client, b.log, ownerRef)
+	// TODO: Add error handler to handle case where Get fails for reasons other than `NotFound`
+	// e.g. network issues, permission issues, etc.
+	_, err = b.client.CoreV1().ServiceAccounts(config.Kubernetes.JobsNamespace).Get(timeoutCtx, saName, metav1.GetOptions{})
+
+	// ServiceAccount does not exist, create it
+	if err != nil {
+		b.log.Debug("Error getting ServiceAccount:", "ServiceAccount", saName, "taskID", task.Id, "error", err)
+		b.log.Debug("Creating Worker ServiceAccount", "taskID", task.Id)
+		// Only set the owner reference for task-level SAs; external SAs are shared and must not be GC'd with the job.
+		saOwnerRef := ownerRef
+		if externalSA {
+			saOwnerRef = nil
+		}
+		err = resources.CreateServiceAccount(timeoutCtx, task, config, b.client, b.log, saOwnerRef)
 		if err != nil {
 			_ = b.Cancel(context.Background(), task.Id)
-			return fmt.Errorf("creating Worker Role: %w", err)
+			return fmt.Errorf("creating Worker ServiceAccount: %w", err)
 		}
+	} else {
+		b.log.Debug("ServiceAccount already exists, skipping creation", "ServiceAccount", saName, "taskID", task.Id)
 	}
 
-	if config.Kubernetes.RoleBindingTemplate != "" {
-		b.log.Debug("creating Worker RoleBinding", "taskID", task.Id)
-		err = resources.CreateRoleBinding(timeoutCtx, task, config, b.client, b.log, ownerRef)
-		if err != nil {
-			_ = b.Cancel(context.Background(), task.Id)
-			return fmt.Errorf("creating Worker RoleBinding: %w", err)
-		}
+	b.log.Debug("creating Worker Role", "taskID", task.Id)
+	err = resources.CreateRole(timeoutCtx, task, config, b.client, b.log, ownerRef)
+	if err != nil {
+		_ = b.Cancel(context.Background(), task.Id)
+		return fmt.Errorf("creating Worker Role: %w", err)
+	}
+
+	b.log.Debug("creating Worker RoleBinding", "taskID", task.Id)
+	err = resources.CreateRoleBinding(timeoutCtx, task, config, b.client, b.log, ownerRef)
+	if err != nil {
+		_ = b.Cancel(context.Background(), task.Id)
+		return fmt.Errorf("creating Worker RoleBinding: %w", err)
 	}
 
 	// If the task has inputs, outputs, or declared volumes, create a PVC so

--- a/compute/kubernetes/backend_test.go
+++ b/compute/kubernetes/backend_test.go
@@ -28,6 +28,60 @@ func (n *noopEventWriter) WriteEvent(ctx context.Context, ev *events.Event) erro
 
 func (n *noopEventWriter) Close() {}
 
+const (
+	configMapTemplate = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: funnel-worker-config-{{.TaskId}}
+  namespace: {{.Namespace}}
+data:
+  config.yaml: "placeholder"
+`
+	serviceAccountTemplate = `apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: funnel-worker-sa-{{.Namespace}}-{{.TaskId}}
+  namespace: {{.Namespace}}
+  labels:
+    app: funnel
+    taskId: {{.TaskId}}
+`
+	roleTemplate = `apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: funnel-worker-sa-{{.Namespace}}-{{.TaskId}}-role
+  namespace: {{.Namespace}}
+  labels:
+    app: funnel
+    taskId: {{.TaskId}}
+rules: []
+`
+	roleBindingTemplate = `apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: funnel-worker-sa-{{.Namespace}}-{{.TaskId}}-binding
+  namespace: {{.Namespace}}
+  labels:
+    app: funnel
+    taskId: {{.TaskId}}
+subjects:
+- kind: ServiceAccount
+  name: funnel-worker-sa-{{.Namespace}}-{{.TaskId}}
+  namespace: {{.Namespace}}
+roleRef:
+  kind: Role
+  name: funnel-worker-sa-{{.Namespace}}-{{.TaskId}}-role
+  apiGroup: rbac.authorization.k8s.io
+`
+)
+
+func applyKubernetesTemplates(conf *config.Config) {
+	conf.Kubernetes.ConfigMapTemplate = configMapTemplate
+	conf.Kubernetes.ServiceAccountTemplate = serviceAccountTemplate
+	conf.Kubernetes.RoleTemplate = roleTemplate
+	conf.Kubernetes.RoleBindingTemplate = roleBindingTemplate
+}
+
 func TestTaskSubmission(t *testing.T) {
 	// Create a fake Kubernetes client
 	fakeClient := fake.NewSimpleClientset()
@@ -56,14 +110,7 @@ spec:
             memory: "{{.RamGb}}Gi"
             ephemeral-storage: "{{.DiskGb}}Gi"
 `
-	conf.Kubernetes.ConfigMapTemplate = `apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: funnel-worker-config-{{.TaskId}}
-  namespace: {{.Namespace}}
-data:
-  config.yaml: "placeholder"
-`
+	applyKubernetesTemplates(conf)
 
 	// Create a logger
 	log := logger.NewLogger("test", logger.DefaultConfig())
@@ -173,6 +220,8 @@ func TestSubmit_AppliesNodeSelectorAndTolerationsToWorkerJob(t *testing.T) {
 			Effect:   "NoSchedule",
 		},
 	}
+
+	applyKubernetesTemplates(conf)
 
 	// Include scheduling blocks in the worker template under test.
 	conf.Kubernetes.WorkerTemplate = `


### PR DESCRIPTION
# Overview 🌀

This PR reverts a breaking change in the develop branch where resource template `if` checks were added in Commit [957d200](https://github.com/calypr/funnel/commit/957d200a878546a8f8f2ce281ab200d9e0a396e6)

## Current Behavior ❌

This change was originally introduced to resolve the following K8s Backend Resource tests:

- [`TestTaskSubmission`](https://github.com/calypr/funnel/blob/2026-05-06/compute/kubernetes/backend_test.go#L31)

- [`TestSubmit_AppliesNodeSelectorAndTolerationsToWorkerJob`](https://github.com/calypr/funnel/blob/2026-05-06/compute/kubernetes/backend_test.go#L138)

## New Behavior ✔️

To fix these errors (without breaking the K8s backend), minimal resource templates were simply added to the the tests themselves in Commit [ec130c7](https://github.com/calypr/funnel/commit/ec130c7647288f3cc60b850523f82005de1f12dc)

