### PR TITLE
fix: Add support for single-element/single-quote shell commands

### DIFF
--- a/worker/kubernetes.go
+++ b/worker/kubernetes.go
@@ -72,6 +72,24 @@ func (e *K8sSystemErr) Unwrap() error {
 	return e.Err
 }
 
+// normalizeShellCommand ensures a single-element command string is safe to
+// pass to /bin/sh -c. If the string is already valid shell syntax it is
+// returned unchanged. If the parser rejects it (e.g. an unterminated single
+// quote in "echo Hello O'hare!"), each whitespace-separated token is wrapped
+// in single quotes with any internal single quotes escaped, preserving the
+// original word boundaries.
+func normalizeShellCommand(s string) string {
+	if _, err := syntax.NewParser().Parse(strings.NewReader(s), ""); err == nil {
+		return s
+	}
+	tokens := strings.Fields(s)
+	for i, tok := range tokens {
+		escaped := strings.ReplaceAll(tok, "'", "'\\''")
+		tokens[i] = "'" + escaped + "'"
+	}
+	return strings.Join(tokens, " ")
+}
+
 // Create the Executor K8s job from kubernetes-executor-template.yaml
 // Funnel Worker job is created in compute/kubernetes/backend.go#CreateResources
 func (kcmd KubernetesCommand) Run(ctx context.Context) error {
@@ -113,12 +131,10 @@ func (kcmd KubernetesCommand) Run(ctx context.Context) error {
 		cmd = []string{shellCmd}
 	}
 
-	// Validate single-element shell scripts before passing them to /bin/sh -c.
+	// Normalize single-element shell scripts before passing them to /bin/sh -c.
 	// Multi-element commands are exec'd directly and bypass the shell entirely.
 	if len(cmd) == 1 && !hasRedirects {
-		if err := validateShellSyntax(cmd[0]); err != nil {
-			return err
-		}
+		cmd[0] = normalizeShellCommand(cmd[0])
 	}
 
 	// Use a shell wrapper when the command is a single element (a shell script
@@ -452,14 +468,4 @@ func getKubernetesClientset() (*kubernetes.Clientset, error) {
 
 	clientset, err := kubernetes.NewForConfig(kubeconfig)
 	return clientset, err
-}
-
-// validateShellSyntax returns an error if s is not valid POSIX shell syntax.
-// Used to catch issues like unterminated quotes before passing single-element
-// commands to /bin/sh -c. Multi-element commands bypass the shell entirely.
-func validateShellSyntax(s string) error {
-	if _, err := syntax.NewParser().Parse(strings.NewReader(s), ""); err != nil {
-		return fmt.Errorf("single-element command is not valid shell syntax (consider using a multi-element command array instead): %w", err)
-	}
-	return nil
 }


### PR DESCRIPTION
# Overview

This PR updates support for single-element/single-quote shell commands!

## Current Behavior ❌

> [!CAUTION]
> 
> Tested with Helm Chart [v0.1.99-rc.34](https://quay.io/ohsu-comp-bio/funnel:2026-05-11) + [2026-05-11](https://quay.io/ohsu-comp-bio/funnel:2026-05-11)

`quote-test.json`
```json
{
  "name": "single-quote test",
  "executors": [
    {
      "image": "bash",
      "command": ["echo Hello O'hare!"]
    }
  ]
}
```

```sh
➜ funnel task create quote-test.json
<TASK ID>

➜ kubectl logs  <WORKER POD> -n jobs
Error: single-element command is not valid shell syntax (consider using a multi-element command array instead): 1:13: reached EOF without closing quote `'`
```

This new warning was added in Commit [c1ee4c7](https://github.com/calypr/funnel/commit/c1ee4c7ac0ff12d331e078c87aa317e8085f4aaf) to safeguard against the following error when attempting to submit a single-element/single-quote command:

```sh
/bin/sh: syntax error: unterminated quoted string
```

## New Behavior ✔️

> [!TIP]
> 
> Tested with Helm Chart [v0.1.99-rc.34](https://quay.io/ohsu-comp-bio/funnel:2026-05-11) + [dbc71a5](https://quay.io/ohsu-comp-bio/funnel:dbc71a5)

```sh
➜ funnel task create quote-test.json
<TASK ID>

➜ kubectl get jobs -n jobs
NAME         STATUS     COMPLETIONS   DURATION   AGE
<WORKER>     Complete   1/1           6s         8s
<EXECUTOR>   Complete   1/1           3s         6s

➜ funnel task get <TASK ID>
{
  "executors": [
    {
      "command": [
        "echo Hello O'hare!"
      ],
      "image": "bash"
    }
  ],
  "id": "<TASK ID>",
  "logs": [
    {
      "logs": [
        {
          "stdout": "Hello O'hare!\n"
        }
      ],
    }
  ],
  "state": "COMPLETE"
}
```

### Backwards Compatibility

> [!TIP]
> 
> `nf-canary` tests passing when tested aginast Helm Chart [v0.1.99-rc.34](https://quay.io/ohsu-comp-bio/funnel:2026-05-11) + [dbc71a5](https://quay.io/ohsu-comp-bio/funnel:dbc71a5):

```sh
➜ nextflow run main.nf -c nextflow.config.tes -w s3://local/work

 N E X T F L O W   ~  version 25.10.5

Launching `main.nf` [focused_booth] DSL2 - revision: 7e7cf52ccc

Uploading local `bin` scripts folder to s3://local/work/tmp/...
[45/f901f7] process > NF_CANARY:TEST_SUCCESS (1)              [100%] 1 of 1 ✔
[ee/bc5e7f] process > NF_CANARY:TEST_CREATE_FILE (1)          [100%] 1 of 1 ✔
[8f/c2a61e] process > NF_CANARY:TEST_CREATE_EMPTY_FILE (1)    [100%] 1 of 1 ✔
[7e/2f9376] process > NF_CANARY:TEST_CREATE_FOLDER (1)        [100%] 1 of 1 ✔
[74/3cca91] process > NF_CANARY:TEST_INPUT (1)                [100%] 1 of 1 ✔
[85/1367a1] process > NF_CANARY:TEST_BIN_SCRIPT (1)           [100%] 1 of 1 ✔
[-        ] process > NF_CANARY:TEST_STAGE_REMOTE             -
[9e/70c2a1] process > NF_CANARY:TEST_PASS_FILE (1)            [100%] 1 of 1 ✔
[60/6a4916] process > NF_CANARY:TEST_PASS_FOLDER (1)          [100%] 1 of 1 ✔
[04/59a90a] process > NF_CANARY:TEST_PUBLISH_FILE (1)         [100%] 1 of 1 ✔
[54/8b904a] process > NF_CANARY:TEST_PUBLISH_FOLDER (1)       [100%] 1 of 1 ✔
[ec/ead5c9] process > NF_CANARY:TEST_IGNORED_FAIL (1)         [100%] 1 of 1, ignored: 1 ✔
[7c/6cc58d] process > NF_CANARY:TEST_MV_FILE (1)              [100%] 1 of 1 ✔
[1e/ff3e3b] process > NF_CANARY:TEST_MV_FOLDER_CONTENTS (1)   [100%] 1 of 1 ✔
[7b/045ec6] process > NF_CANARY:TEST_VAL_INPUT (1)            [100%] 1 of 1 ✔
[-        ] process > NF_CANARY:TEST_GPU                      -
[-        ] process > NF_CANARY:TEST_FUSION_DOCTOR            -
[-        ] process > NF_CANARY:FUSION_DOCTOR_GENERATE_REPORT -
[ec/ead5c9] NOTE: Process `NF_CANARY:TEST_IGNORED_FAIL (1)` terminated with an error exit status (1) -- Error is ignored
Completed at: 12-May-2026 16:39:46
Duration    : 1m 17s
CPU hours   : (a few seconds)
Succeeded   : 13
Ignored     : 1
Failed      : 1
```