### PR TITLE
chore: Remove MinIO v6 dep in favor of MinIO v7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kr/pretty v0.3.1
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/minio/minio-go v6.0.14+incompatible
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/moby/term v0.5.2 // indirect
 	github.com/ncw/swift v1.0.53
@@ -74,7 +73,7 @@ require (
 	github.com/hashicorp/go-plugin v1.7.0
 	github.com/jackc/pgx/v5 v5.9.1
 	github.com/lestrrat-go/jwx/v2 v2.1.6
-	github.com/minio/minio-go/v7 v7.0.100
+	github.com/minio/minio-go/v7 v7.1.0
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0
 	go.mongodb.org/mongo-driver/v2 v2.5.1
@@ -112,6 +111,7 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.3 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
+	github.com/zeebo/xxh3 v1.1.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0 // indirect
 	mvdan.cc/sh/v3 v3.13.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -497,6 +497,8 @@ github.com/minio/minio-go v6.0.14+incompatible h1:fnV+GD28LeqdN6vT2XdGKW8Qe/IfjJ
 github.com/minio/minio-go v6.0.14+incompatible/go.mod h1:7guKYtitv8dktvNUGrhzmNlA5wrAABTQXCoesZdFQO8=
 github.com/minio/minio-go/v7 v7.0.100 h1:ShkWi8Tyj9RtU57OQB2HIXKz4bFgtVib0bbT1sbtLI8=
 github.com/minio/minio-go/v7 v7.0.100/go.mod h1:EtGNKtlX20iL2yaYnxEigaIvj0G0GwSDnifnG8ClIdw=
+github.com/minio/minio-go/v7 v7.1.0 h1:QEt5IStDpxgGjEdtOgpiZ5QhmSl3ax7qy61vi2SwHO8=
+github.com/minio/minio-go/v7 v7.1.0/go.mod h1:Dm7WS1AgLmBa0NcQD6SeJnJf+K/EUW3GR7Ks6olB3OA=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
@@ -685,6 +687,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
+github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 go.einride.tech/aip v0.83.0 h1:TI21IdeOnLTwZEJ3BxtImIZk6bsN2Q+sd0x99SLiQ+M=
 go.einride.tech/aip v0.83.0/go.mod h1:E8+wdTApA70odnpFzJgsGogHozC2JCIhFJBKPr8bVig=

--- a/tests/storage/generic_s3_test.go
+++ b/tests/storage/generic_s3_test.go
@@ -6,25 +6,81 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/minio/minio-go"
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/ohsu-comp-bio/funnel/config"
 	"github.com/ohsu-comp-bio/funnel/events"
 	"github.com/ohsu-comp-bio/funnel/storage"
 	"github.com/ohsu-comp-bio/funnel/tes"
 	"github.com/ohsu-comp-bio/funnel/tests"
 	"github.com/ohsu-comp-bio/funnel/worker"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
 )
 
+const (
+	minioKey    = "minioadmin"
+	minioSecret = "minioadmin"
+)
+
+// startMinio launches a temporary MinIO container and returns the host:port
+// endpoint. The container is terminated when t finishes.
+func startMinio(t *testing.T) string {
+	t.Helper()
+
+	ctx := context.Background()
+	ctr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "quay.io/minio/minio:latest",
+			ExposedPorts: []string{"9000/tcp"},
+			Env: map[string]string{
+				"MINIO_ROOT_USER":     minioKey,
+				"MINIO_ROOT_PASSWORD": minioSecret,
+			},
+			Cmd:        []string{"server", "/data"},
+			WaitingFor: wait.ForHTTP("/minio/health/ready").WithPort("9000"),
+		},
+		Started: true,
+	})
+	if err != nil {
+		t.Skipf("could not start MinIO container (is Docker running?): %v", err)
+	}
+
+	t.Cleanup(func() {
+		testcontainers.TerminateContainer(ctr)
+	})
+
+	host, err := ctr.Host(ctx)
+	if err != nil {
+		testcontainers.TerminateContainer(ctr)
+		t.Fatal("could not get MinIO container host:", err)
+	}
+	port, err := ctr.MappedPort(ctx, "9000")
+	if err != nil {
+		testcontainers.TerminateContainer(ctr)
+		t.Fatal("could not get MinIO container port:", err)
+	}
+
+	return host + ":" + port.Port()
+}
+
 func TestGenericS3Storage(t *testing.T) {
-	conf = tests.DefaultConfig()
 	tests.SetLogOutput(log, t)
 	defer os.RemoveAll("./test_tmp")
 
-	if len(conf.GenericS3) > 0 {
-		if !conf.GenericS3[0].Valid() {
-			t.Skipf("Skipping generic s3 e2e tests...")
+	if len(conf.GenericS3) == 0 {
+		endpoint := startMinio(t)
+		conf.GenericS3 = []*config.GenericS3Storage{
+			{
+				Endpoint: endpoint,
+				Key:      minioKey,
+				Secret:   minioSecret,
+			},
 		}
-	} else {
+		t.Cleanup(func() { conf.GenericS3 = nil })
+	}
+
+	if !conf.GenericS3[0].Valid() {
 		t.Skipf("Skipping generic s3 e2e tests...")
 	}
 
@@ -144,13 +200,13 @@ func TestGenericS3Storage(t *testing.T) {
 	}
 
 	err = worker.DownloadInputs(ctx, []*tes.Input{
-		{Url: outDirURL, Path: "./test_tmp/test-s3-directory"},
+		{Url: outDirURL, Path: "./test_tmp/test-s3-directory", Type: tes.Directory},
 	}, store, ev, parallelXfer)
 	if err != nil {
 		t.Fatal("Failed to download directory:", err)
 	}
 
-	b, err = os.ReadFile("./test_tmp/test-s3-directory/test-output-directory/test-output-file.txt")
+	b, err = os.ReadFile("./test_tmp/test-s3-directory/test-output-file.txt")
 	if err != nil {
 		t.Fatal("Failed to read file in downloaded directory", err)
 	}
@@ -214,8 +270,20 @@ type minioTest struct {
 }
 
 func newMinioTest(conf *config.GenericS3Storage) (*minioTest, error) {
-	ssl := strings.HasPrefix(conf.Endpoint, "https")
-	client, err := minio.NewV2(conf.Endpoint, conf.Key, conf.Secret, ssl)
+	endpoint := conf.Endpoint
+	secure := strings.HasPrefix(endpoint, "https")
+	// Remove scheme from endpoint if present
+	if secure {
+		endpoint = strings.TrimPrefix(endpoint, "https://")
+	} else {
+		endpoint = strings.TrimPrefix(endpoint, "http://")
+	}
+
+	client, err := minio.New(endpoint, &minio.Options{
+		Creds:  credentials.NewStaticV4(conf.Key, conf.Secret, ""),
+		Secure: secure,
+		Region: conf.Region,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -229,18 +297,20 @@ func newMinioTest(conf *config.GenericS3Storage) (*minioTest, error) {
 }
 
 func (b *minioTest) createBucket(bucket string) error {
-	return b.client.MakeBucket(bucket, "")
+	return b.client.MakeBucket(context.Background(), bucket, minio.MakeBucketOptions{})
 }
 
 func (b *minioTest) deleteBucket(bucket string) error {
-	doneCh := make(chan struct{})
-	defer close(doneCh)
+	ctx := context.Background()
 	recursive := true
-	for obj := range b.client.ListObjects(bucket, "", recursive, doneCh) {
-		err := b.client.RemoveObject(bucket, obj.Key)
+	for obj := range b.client.ListObjects(ctx, bucket, minio.ListObjectsOptions{Recursive: recursive}) {
+		if obj.Err != nil {
+			return obj.Err
+		}
+		err := b.client.RemoveObject(ctx, bucket, obj.Key, minio.RemoveObjectOptions{})
 		if err != nil {
 			return err
 		}
 	}
-	return b.client.RemoveBucket(bucket)
+	return b.client.RemoveBucket(ctx, bucket)
 }


### PR DESCRIPTION
# Overview

This PR removes the MinIO v6 dependency in favor of MinIO v7 in [`go.mod`](https://github.com/calypr/funnel/pull/1415/changes#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L37)!