### PR TITLE
fix: report EXECUTOR_ERROR when output upload fails after executor failure

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -337,7 +337,17 @@ func (r *DefaultWorker) Run(pctx context.Context) (runerr error) {
 	// where the worker itself is in a bad state.
 	var outputLog []*tes.OutputFileLog
 	if run.syserr == nil {
-		outputLog, run.syserr = UploadOutputs(ctx, mapper.Outputs, r.Store, event, int(r.Conf.MaxParallelTransfers))
+		var uploadErr error
+		outputLog, uploadErr = UploadOutputs(ctx, mapper.Outputs, r.Store, event, int(r.Conf.MaxParallelTransfers))
+		if uploadErr != nil {
+			if run.execerr != nil {
+				// The executor already failed; treat upload errors as warnings so the
+				// task is reported as EXECUTOR_ERROR rather than SYSTEM_ERROR.
+				event.Error("Failed to upload outputs after executor error", "error", uploadErr)
+			} else {
+				run.syserr = uploadErr
+			}
+		}
 	}
 
 	// unmap paths for OutputFileLog


### PR DESCRIPTION
# Overview 🌀

This PR addresses Slack [Issue #76](https://ohsucomputationalbio.slack.com/lists/T04MS9FKW/F079AU1KCUX?record_id=Rec0B20LYDW1W) by ensuring that output upload errors result in EXECUTOR_ERROR task states.

## Current Behavior ⚠️

- When an executor fails mid-script, expected output files may not be created, causing S3 upload failures that were incorrectly reported as `SYSTEM_ERROR`

## New Behavior ✔️

- Upload errors that occur after an executor failure are now logged as warnings and do not override the task's final state — the task is correctly reported as `EXECUTOR_ERROR`
- If there is no prior executor failure, upload errors continue to be treated as `SYSTEM_ERROR` (unchanged behavior)

## Test Steps ⚙️ 

- [ ] Run a task with a script that fails before producing its declared output files and confirm the task ends in `EXECUTOR_ERROR`, not `SYSTEM_ERROR`
- [ ] Run a task that succeeds but has a storage misconfiguration causing upload failure and confirm it still ends in `SYSTEM_ERROR`