### PR TITLE
fix: render TES task volumes as emptyDir in K8s executor jobs

### DIFF
--- a/compute/kubernetes/backend.go
+++ b/compute/kubernetes/backend.go
@@ -254,9 +254,10 @@ func (b *Backend) createResources(ctx context.Context, task *tes.Task, config *c
 		}
 	}
 
-	// If the task has inputs, outputs, or declared volumes, create a PVC so
-	// executor pods can share data via PVC subPath mounts.
-	if len(task.Inputs) > 0 || len(task.Outputs) > 0 || len(task.Volumes) > 0 {
+	// If the task has inputs or outputs, create a PVC so executor pods can
+	// share data via PVC subPath mounts. TES task.Volumes are rendered as
+	// emptyDir volumes in the executor job template and do not need a PVC.
+	if len(task.Inputs) > 0 || len(task.Outputs) > 0 {
 		b.log.Debug("creating Worker PV", "taskID", task.Id)
 
 		// Check to make sure required configs are present

--- a/compute/kubernetes/resources/job.go
+++ b/compute/kubernetes/resources/job.go
@@ -82,7 +82,7 @@ func CreateJob(ctx context.Context, task *tes.Task, conf *config.Config, client 
 		"DiskGb":             res.GetDiskGb(),
 		"Image":              image,
 		"BackoffLimit":       backoffLimit,
-		"NeedsPVC":           len(task.Inputs) > 0 || len(task.Outputs) > 0 || len(task.Volumes) > 0,
+		"NeedsPVC":           len(task.Inputs) > 0 || len(task.Outputs) > 0,
 		"NodeSelector":       conf.Kubernetes.NodeSelector,
 		"Tolerations":        conf.Kubernetes.Tolerations,
 		"ServiceAccountName": fmt.Sprintf("funnel-worker-sa-%s-%s", conf.Kubernetes.JobsNamespace, task.Id),

--- a/config/kubernetes/executor-job.yaml
+++ b/config/kubernetes/executor-job.yaml
@@ -69,12 +69,16 @@ spec:
 
         volumeMounts:
         {{- if .NeedsPVC }}
-          {{- range $idx, $item := .Volumes}}
-          - name: funnel-storage-{{$.TaskId}}
-            mountPath: {{$item.ContainerPath}}
-            subPath: {{$.TaskId}}{{$item.ContainerPath}}
-          {{- end}}
+        {{- range $idx, $item := .Volumes}}
+        - name: funnel-storage-{{$.TaskId}}
+          mountPath: {{$item.ContainerPath}}
+          subPath: {{$.TaskId}}{{$item.ContainerPath}}
+        {{- end}}
         {{- end }}
+        {{- range $idx, $vol := .TaskVolumes}}
+        - name: funnel-vol-{{$idx}}
+          mountPath: {{$vol}}
+        {{- end}}
 
       volumes:
       {{- if .NeedsPVC }}
@@ -82,3 +86,7 @@ spec:
         persistentVolumeClaim:
           claimName: funnel-worker-pvc-{{.TaskId}}
       {{- end }}
+      {{- range $idx, $vol := .TaskVolumes}}
+      - name: funnel-vol-{{$idx}}
+        emptyDir: {}
+      {{- end}}

--- a/worker/kubernetes.go
+++ b/worker/kubernetes.go
@@ -38,6 +38,7 @@ type KubernetesCommand struct {
 	ResourceLimits *tes.Resources
 	ServiceAccount string
 	NeedsPVC       bool
+	TaskVolumes    []string // TES task.Volumes container paths; rendered as emptyDir volumes
 	Clientset      kubernetes.Interface
 	Command
 }
@@ -150,6 +151,7 @@ func (kcmd KubernetesCommand) Run(ctx context.Context) error {
 		"UseShell":           useShell,
 		"Workdir":            kcmd.Workdir,
 		"Volumes":            kcmd.Volumes,
+		"TaskVolumes":        kcmd.TaskVolumes,
 		"Env":                kcmd.Env,
 		"Cpus":               kcmd.Resources.CpuCores,
 		"RamGb":              kcmd.Resources.RamGb,

--- a/worker/kubernetes_volumes_test.go
+++ b/worker/kubernetes_volumes_test.go
@@ -1,0 +1,176 @@
+package worker
+
+import (
+	"bytes"
+	"os"
+	"testing"
+	"text/template"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func renderExecutorJobWithVolumes(t *testing.T, taskVolumes []string, pvcVolumes []Volume, needsPVC bool) *batchv1.Job {
+	t.Helper()
+
+	tmplBytes, err := os.ReadFile("../config/kubernetes/executor-job.yaml")
+	if err != nil {
+		t.Fatalf("read executor-job.yaml: %v", err)
+	}
+
+	tpl, err := template.New("executor").Parse(string(tmplBytes))
+	if err != nil {
+		t.Fatalf("parse template: %v", err)
+	}
+
+	data := map[string]interface{}{
+		"TaskId":             "task-abc",
+		"JobId":              0,
+		"Namespace":          "test-ns",
+		"JobsNamespace":      "test-ns",
+		"Command":            []string{"echo ok"},
+		"UseShell":           false,
+		"Workdir":            "/",
+		"Volumes":            pvcVolumes,
+		"TaskVolumes":        taskVolumes,
+		"Env":                map[string]string{},
+		"Cpus":               "100m",
+		"RamGb":              "128Mi",
+		"DiskGb":             "1Gi",
+		"CpusLimit":          "0",
+		"RamGbLimit":         "0",
+		"DiskGbLimit":        "0",
+		"Image":              "alpine",
+		"NeedsPVC":           needsPVC,
+		"NodeSelector":       nil,
+		"Tolerations":        nil,
+		"ServiceAccountName": "funnel-sa-test-ns",
+	}
+
+	var buf bytes.Buffer
+	if err := tpl.Execute(&buf, data); err != nil {
+		t.Fatalf("execute template: %v\nrendered:\n%s", err, buf.String())
+	}
+
+	obj, _, err := scheme.Codecs.UniversalDeserializer().Decode(buf.Bytes(), nil, nil)
+	if err != nil {
+		t.Fatalf("decode rendered template: %v\nrendered:\n%s", err, buf.String())
+	}
+
+	job, ok := obj.(*batchv1.Job)
+	if !ok {
+		t.Fatalf("decoded object is not Job: %T", obj)
+	}
+	return job
+}
+
+// TestTaskVolumesRenderedAsEmptyDir verifies that TES task.Volumes are rendered
+// as emptyDir volumes (not PVC mounts) in the executor job pod spec.
+func TestTaskVolumesRenderedAsEmptyDir(t *testing.T) {
+	job := renderExecutorJobWithVolumes(t,
+		[]string{"/vol", "/tmp/shared"},
+		nil,  // no PVC volumes
+		false, // no PVC needed
+	)
+
+	podSpec := job.Spec.Template.Spec
+
+	// Expect two volumes, both emptyDir
+	if len(podSpec.Volumes) != 2 {
+		t.Fatalf("expected 2 volumes, got %d: %+v", len(podSpec.Volumes), podSpec.Volumes)
+	}
+	for _, v := range podSpec.Volumes {
+		if v.EmptyDir == nil {
+			t.Errorf("volume %q should be emptyDir, got: %+v", v.Name, v.VolumeSource)
+		}
+	}
+
+	// Expect two volumeMounts in the container
+	if len(podSpec.Containers) == 0 {
+		t.Fatal("no containers in pod spec")
+	}
+	mounts := podSpec.Containers[0].VolumeMounts
+	if len(mounts) != 2 {
+		t.Fatalf("expected 2 volumeMounts, got %d: %+v", len(mounts), mounts)
+	}
+
+	mountPaths := map[string]bool{}
+	for _, m := range mounts {
+		mountPaths[m.MountPath] = true
+	}
+	for _, vol := range []string{"/vol", "/tmp/shared"} {
+		if !mountPaths[vol] {
+			t.Errorf("expected mountPath %q not found in mounts: %+v", vol, mounts)
+		}
+	}
+}
+
+// TestTaskVolumesDoNotUsePVC verifies that when a task only has volumes (no
+// inputs/outputs), no PVC volume appears in the pod spec.
+func TestTaskVolumesDoNotUsePVC(t *testing.T) {
+	job := renderExecutorJobWithVolumes(t,
+		[]string{"/data"},
+		nil,
+		false,
+	)
+
+	for _, v := range job.Spec.Template.Spec.Volumes {
+		if v.PersistentVolumeClaim != nil {
+			t.Errorf("unexpected PVC volume %q when task has only TES volumes", v.Name)
+		}
+	}
+}
+
+// TestTaskVolumesAndPVCCoexist verifies that a task with both inputs (PVC) and
+// TES volumes renders both a PVC mount and emptyDir mounts without conflict.
+func TestTaskVolumesAndPVCCoexist(t *testing.T) {
+	pvcVols := []Volume{
+		{HostPath: "/work/inputs/file.txt", ContainerPath: "/inputs/file.txt", Readonly: false},
+	}
+	job := renderExecutorJobWithVolumes(t,
+		[]string{"/vol"},
+		pvcVols,
+		true, // has PVC for inputs
+	)
+
+	podSpec := job.Spec.Template.Spec
+
+	var hasEmptyDir, hasPVC bool
+	for _, v := range podSpec.Volumes {
+		if v.EmptyDir != nil {
+			hasEmptyDir = true
+		}
+		if v.PersistentVolumeClaim != nil {
+			hasPVC = true
+		}
+	}
+
+	if !hasEmptyDir {
+		t.Error("expected at least one emptyDir volume for TES task volume")
+	}
+	if !hasPVC {
+		t.Error("expected PVC volume for inputs")
+	}
+
+	// Verify no mountPath appears twice
+	mounts := podSpec.Containers[0].VolumeMounts
+	seen := map[string]int{}
+	for _, m := range mounts {
+		seen[m.MountPath]++
+	}
+	for path, count := range seen {
+		if count > 1 {
+			t.Errorf("mountPath %q appears %d times — duplicate mount", path, count)
+		}
+	}
+
+	// Verify the emptyDir mount does not use a subPath (subPath is PVC-specific)
+	for _, m := range mounts {
+		if m.MountPath == "/vol" && m.SubPath != "" {
+			t.Errorf("emptyDir mount at /vol should not have subPath, got %q", m.SubPath)
+		}
+	}
+
+	_ = corev1.EmptyDirVolumeSource{} // ensure corev1 import used
+}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -226,6 +226,21 @@ func (r *DefaultWorker) Run(pctx context.Context) (runerr error) {
 					// return fmt.Errorf("error writing resources event for task %s: %v", task.Id, err)
 				}
 
+				// Build a set of TES task volume paths so they can be excluded
+				// from PVC mounts — TES volumes are rendered as emptyDir instead.
+				taskVolSet := make(map[string]bool, len(task.GetVolumes()))
+				for _, v := range task.GetVolumes() {
+					taskVolSet[v] = true
+				}
+				var pvcVolumes []Volume
+				for _, v := range mapper.Volumes {
+					if !taskVolSet[v.ContainerPath] {
+						pvcVolumes = append(pvcVolumes, v)
+					}
+				}
+				pvcCommand := command
+				pvcCommand.Volumes = pvcVolumes
+
 				taskCommand = &KubernetesCommand{
 					TaskId:         task.Id,
 					JobId:          i,
@@ -237,8 +252,9 @@ func (r *DefaultWorker) Run(pctx context.Context) (runerr error) {
 					JobsNamespace:  r.Executor.JobsNamespace,
 					Resources:      resources,
 					ResourceLimits: resourceLimits,
-					Command:        command,
-					NeedsPVC:       len(task.GetInputs()) > 0 || len(task.GetOutputs()) > 0 || len(task.GetVolumes()) > 0,
+					Command:        pvcCommand,
+					NeedsPVC:       len(task.GetInputs()) > 0 || len(task.GetOutputs()) > 0,
+					TaskVolumes:    task.GetVolumes(),
 					NodeSelector:   r.Executor.NodeSelector,
 					Tolerations:    r.Executor.Tolerations,
 					ServiceAccount: fmt.Sprintf("funnel-worker-sa-%s-%s", r.Executor.JobsNamespace, task.Id),


### PR DESCRIPTION
# Overview 🌀

This PR fixes TES `task.Volumes` support in the Kubernetes backend to comply with the TES spec: volumes must be initialized as **empty directories** shared between all executors in a task, not backed by the S3 PVC.

## Current Behavior ❌

TES `task.Volumes` were mounted as subpath mounts on the S3-backed PVC (`funnel-storage-<taskId>`), the same volume used for inputs/outputs. This caused two bugs:

1. If a volume path overlapped with the PVC mount point (e.g. `/mnt/data`), the PV contents were exposed instead of an empty directory.
2. Volumes were not truly empty or shared between executors as independent scratch space — they were subpath slices of a persistent S3 bucket.

## New Behavior ✔️

Each path in `task.Volumes` is now rendered as a Kubernetes `emptyDir` volume in the executor job pod spec. The `emptyDir` is mounted at the declared path in every executor container, so data written by one executor is readable by the next — matching Docker's `-v` behavior as required by the TES spec.

Additionally, the S3 PVC is only created when the task has `inputs` or `outputs`. A task with only `volumes` no longer provisions a PVC at all.

## Changes

| File | Change |
|------|--------|
| `config/kubernetes/executor-job.yaml` | TES `TaskVolumes` render as `emptyDir` volumes with matching `volumeMounts`. PVC mounts are now only for inputs/outputs. |
| `worker/kubernetes.go` | Added `TaskVolumes []string` field to `KubernetesCommand`; passed to template data. |
| `worker/worker.go` | Filters `mapper.Volumes` to exclude TES task volume paths before passing to the K8s command (prevents double-mounting). `NeedsPVC` is now `true` only when inputs or outputs exist. |
| `compute/kubernetes/backend.go` | PV/PVC creation condition updated to `inputs || outputs` only. |
| `compute/kubernetes/resources/job.go` | Same `NeedsPVC` fix for the worker job template. |
| `worker/kubernetes_volumes_test.go` | Three new unit tests: emptyDir rendering, no-PVC for volumes-only tasks, PVC + emptyDir coexistence. |