### PR TITLE
fix: Remove `/tmp` volume from being automatically added to commands

### DIFF
--- a/worker/file_mapper.go
+++ b/worker/file_mapper.go
@@ -75,11 +75,6 @@ func (mapper *FileMapper) MapTask(task *tes.Task) error {
 		}
 	}
 
-	err = mapper.AddTmpVolume("/tmp")
-	if err != nil {
-		return err
-	}
-
 	// Add all the inputs to the mapper
 	for _, input := range task.Inputs {
 		err = mapper.AddInput(input)

--- a/worker/file_mapper_test.go
+++ b/worker/file_mapper_test.go
@@ -105,11 +105,6 @@ func TestMapTask(t *testing.T) {
 			Readonly:      false,
 		},
 		{
-			HostPath:      tmp + "/tmp",
-			ContainerPath: "/tmp",
-			Readonly:      false,
-		},
-		{
 			HostPath:      tmp + "/outputs",
 			ContainerPath: "/outputs",
 			Readonly:      false,
@@ -161,6 +156,14 @@ func TestMapTask(t *testing.T) {
 			t.Log("Diff", d)
 		}
 		t.Fatal("unexpected mapper outputs")
+	}
+
+	for _, vol := range ev {
+		fmt.Println("Expected volume:", vol)
+	}
+
+	for _, vol := range f.Volumes {
+		fmt.Println("Actual volume:", vol)
 	}
 
 	if diff := deep.Equal(f.Volumes, ev); diff != nil {


### PR DESCRIPTION
# Overview 🌀

Removes the implicit `/tmp` volume that Funnel automatically mounted in every container. This volume was originally added in [ae3acc4](https://github.com/calypr/funnel/commit/ae3acc43218af525d03f53716f53c3c505c871e6) as a companion to the `--read-only` Docker flag, to ensure a writable scratch space always exists.

Since it is not part of the [TES spec](https://github.com/ga4gh/task-execution-schemas), tasks that need a writable `/tmp` should declare it explicitly in their task definition.

> [!NOTE]
> 
> The `--read-only` Docker flag is intentionally kept — it is a meaningful security boundary that prevents executors from writing to the container filesystem unexpectedly.

## Current Behavior ⚠️

`/tmp` is automatically mounted as a writable volume in every container, regardless of the task definition:

```jsonc
// No volumes declared — /tmp is silently mounted anyway
{
  "name": "samtools sort",
  "executors": [
    {
      "image": "biocontainers/samtools:v1.9-4-deb_cv1",
      "command": ["samtools", "sort", "-o", "/tmp/output.bam", "/tmp/input.bam"]
    }
  ]
}
```

## New Behavior ✔️

`/tmp` must be explicitly declared in `volumes` for tasks that need it:

```jsonc
{
  "name": "samtools sort",
  "volumes": ["/tmp"],   // <---- Explicitly added /tmp volume
  "executors": [
    {
      "image": "biocontainers/samtools:v1.9-4-deb_cv1",
      "command": ["samtools", "sort", "-o", "/tmp/output.bam", "/tmp/input.bam"]
    }
  ]
}
```

## Breaking Changes? ❌

- [X] Yes! Any task that writes to `/tmp` without declaring it in `volumes` will fail with a read-only filesystem error. Common affected tools include:

- **samtools, GATK, Picard** — write temporary sort/index chunks to `/tmp`
- **Java** — JVM writes performance data and extracted jars to `/tmp`
- **Python** — `tempfile` module and many libraries (e.g. matplotlib, scipy) default to `/tmp`
- **R** — writes temporary files during package loading and data processing
- **Shell tools** — `sort`, `mktemp`, and pipes with large data that spill to disk

> [!IMPORTANT]
>
> Users must add `"volumes": ["/tmp"]` to any task definition that requires a writable `/tmp`.