### PR TITLE
Fix Compliance Test Errors

### DIFF
--- a/database/postgres/tes.go
+++ b/database/postgres/tes.go
@@ -10,6 +10,24 @@ import (
 	"github.com/ohsu-comp-bio/funnel/tes"
 )
 
+// trimUnusedExecutorLogs removes trailing executor log entries that correspond
+// to executors that never ran. On task creation the Postgres backend
+// pre-allocates one empty ExecutorLog per executor (see WriteEvent /
+// Type_TASK_CREATED) because jsonb_set cannot grow a JSON array in place. When a
+// task stops early (e.g. an executor fails with ignore_error=false), the slots
+// for the executors that never ran remain as empty placeholders. An executor
+// that never started has no StartTime, so trim trailing logs with an empty
+// StartTime to match the lazily-grown shape produced by the other backends.
+func trimUnusedExecutorLogs(task *tes.Task) {
+	for _, tl := range task.GetLogs() {
+		logs := tl.Logs
+		for len(logs) > 0 && logs[len(logs)-1].GetStartTime() == "" {
+			logs = logs[:len(logs)-1]
+		}
+		tl.Logs = logs
+	}
+}
+
 // The PostgreSQL struct for minimal projection (only fields outside the JSONB blob)
 type TaskCore struct {
 	ID       string `db:"id"`
@@ -57,6 +75,8 @@ func (db *Postgres) GetTask(ctx context.Context, req *tes.GetTaskRequest) (*tes.
 	task.Id = core.ID
 	task.State = tes.State(tes.State_value[stateStr])
 	// task.Owner = core.Owner
+
+	trimUnusedExecutorLogs(&task)
 
 	switch req.View {
 	case tes.View_BASIC.String():
@@ -156,6 +176,8 @@ func (db *Postgres) ListTasks(ctx context.Context, req *tes.ListTasksRequest) (*
 			fmt.Println("Error unmarshaling task JSON for ListTasks:", err)
 			continue
 		}
+
+		trimUnusedExecutorLogs(&task)
 
 		switch req.View {
 		case tes.View_BASIC.String():

--- a/database/postgres/tes_test.go
+++ b/database/postgres/tes_test.go
@@ -1,0 +1,63 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/ohsu-comp-bio/funnel/tes"
+)
+
+func TestTrimUnusedExecutorLogs(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []*tes.ExecutorLog
+		want int
+	}{
+		{
+			name: "trims trailing never-run executor",
+			in: []*tes.ExecutorLog{
+				{StartTime: "2026-06-12T00:00:00Z", ExitCode: 127},
+				{StartTime: ""}, // never ran
+			},
+			want: 1,
+		},
+		{
+			name: "keeps all when every executor ran",
+			in: []*tes.ExecutorLog{
+				{StartTime: "2026-06-12T00:00:00Z"},
+				{StartTime: "2026-06-12T00:00:01Z"},
+			},
+			want: 2,
+		},
+		{
+			name: "trims all when none ran",
+			in: []*tes.ExecutorLog{
+				{StartTime: ""},
+				{StartTime: ""},
+			},
+			want: 0,
+		},
+		{
+			name: "does not trim a started executor preceding an empty one",
+			in: []*tes.ExecutorLog{
+				{StartTime: ""},
+				{StartTime: "2026-06-12T00:00:00Z"},
+			},
+			want: 2,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			task := &tes.Task{Logs: []*tes.TaskLog{{Logs: tc.in}}}
+			trimUnusedExecutorLogs(task)
+			if got := len(task.Logs[0].Logs); got != tc.want {
+				t.Errorf("expected %d executor logs, got %d", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestTrimUnusedExecutorLogs_NoLogs(t *testing.T) {
+	task := &tes.Task{}
+	trimUnusedExecutorLogs(task) // must not panic
+}

--- a/server/marshal.go
+++ b/server/marshal.go
@@ -108,7 +108,7 @@ func (c *CustomMarshal) DetectView(task *tes.Task) (tes.View, error) {
 		return tes.View_MINIMAL, nil
 	}
 
-	if len(task.Logs[0].SystemLogs) == 0 {
+	if len(task.Logs) == 0 || len(task.Logs[0].SystemLogs) == 0 {
 		return tes.View_BASIC, nil
 	}
 

--- a/server/marshal_test.go
+++ b/server/marshal_test.go
@@ -89,6 +89,58 @@ func TestCustomMarshalDecoder_TaskAcceptsNullTags(t *testing.T) {
 	}
 }
 
+// A task with a CreationTime set but no logs (e.g. just after submission) must
+// not panic when its view is detected. Regression test for an index-out-of-range
+// panic at task.Logs[0] in DetectView.
+func TestDetectView_EmptyLogsDoesNotPanic(t *testing.T) {
+	c := NewMarshaler().(*CustomMarshal)
+
+	task := &tes.Task{
+		Id:           "task-1",
+		CreationTime: "2026-06-12T00:00:00Z",
+		// Logs intentionally empty.
+	}
+
+	view, err := c.DetectView(task)
+	if err != nil {
+		t.Fatalf("DetectView returned error: %v", err)
+	}
+	if view != tes.View_BASIC {
+		t.Fatalf("expected View_BASIC for a task with empty logs, got %v", view)
+	}
+}
+
+// MarshalList must not panic when the first task has a CreationTime but no logs.
+// This is the path that crashed the GRPC gateway when listing freshly submitted
+// tasks.
+func TestMarshalList_FirstTaskWithEmptyLogs(t *testing.T) {
+	c := NewMarshaler().(*CustomMarshal)
+
+	list := &tes.ListTasksResponse{
+		Tasks: []*tes.Task{
+			{
+				Id:           "task-1",
+				State:        tes.State_INITIALIZING,
+				CreationTime: "2026-06-12T00:00:00Z",
+				// Logs intentionally empty.
+			},
+		},
+	}
+
+	out, err := c.MarshalList(list)
+	if err != nil {
+		t.Fatalf("MarshalList returned error: %v", err)
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(out, &payload); err != nil {
+		t.Fatalf("failed to unmarshal MarshalList output: %v", err)
+	}
+	if _, ok := payload["tasks"]; !ok {
+		t.Fatalf("expected tasks field in marshaled list output")
+	}
+}
+
 func TestCustomMarshalDecoder_NonTaskPassthrough(t *testing.T) {
 	m := NewMarshaler()
 	input := []byte(`{"id":"task-123"}`)

--- a/tests/core/worker_test.go
+++ b/tests/core/worker_test.go
@@ -381,6 +381,98 @@ func TestDockerContainerMetadata(t *testing.T) {
 	}
 }
 
+// When an executor fails and ignore_error is false, the task must stop and only
+// the failed executor should produce a log. Regression test for a phantom empty
+// executor log being emitted for executors that never ran.
+func TestExecutorErrorStopsTask(t *testing.T) {
+	tests.SetLogOutput(log, t)
+	conf := tests.DefaultConfig()
+	task := tes.Task{
+		Id: "test-task-" + tes.GenerateID(),
+		Executors: []*tes.Executor{
+			{
+				// "ERROR" is not a command, so this executor fails (exit 127).
+				Image:       "alpine",
+				Command:     []string{"ERROR"},
+				IgnoreError: false,
+			},
+			{
+				Image:   "alpine",
+				Command: []string{"echo", "hello"},
+			},
+		},
+	}
+
+	builder := &events.TaskBuilder{Task: &task}
+	logger := &events.Logger{Log: log}
+	m := &events.MultiWriter{logger, builder}
+
+	w := worker.DefaultWorker{
+		Conf:        conf.Worker,
+		Store:       &storage.Mux{},
+		TaskReader:  taskReader{&task},
+		EventWriter: m,
+	}
+
+	if err := w.Run(context.Background()); err != nil {
+		t.Log(err)
+	}
+
+	if task.State != tes.State_EXECUTOR_ERROR {
+		t.Errorf("expected state EXECUTOR_ERROR, got %s", task.State)
+	}
+
+	// Only the first executor should have run; the second must not produce a log.
+	if got := len(builder.Task.Logs[0].Logs); got != 1 {
+		t.Errorf("expected 1 executor log, got %d", got)
+	}
+}
+
+// When an executor fails but ignore_error is true, subsequent executors must
+// still run, producing a log entry per executor.
+func TestExecutorIgnoreErrorContinuesTask(t *testing.T) {
+	tests.SetLogOutput(log, t)
+	conf := tests.DefaultConfig()
+	task := tes.Task{
+		Id: "test-task-" + tes.GenerateID(),
+		Executors: []*tes.Executor{
+			{
+				Image:       "alpine",
+				Command:     []string{"ERROR"},
+				IgnoreError: true,
+			},
+			{
+				Image:   "alpine",
+				Command: []string{"echo", "hello"},
+			},
+		},
+	}
+
+	builder := &events.TaskBuilder{Task: &task}
+	logger := &events.Logger{Log: log}
+	m := &events.MultiWriter{logger, builder}
+
+	w := worker.DefaultWorker{
+		Conf:        conf.Worker,
+		Store:       &storage.Mux{},
+		TaskReader:  taskReader{&task},
+		EventWriter: m,
+	}
+
+	if err := w.Run(context.Background()); err != nil {
+		t.Log(err)
+	}
+
+	// Both executors should have run, each producing a log entry.
+	if got := len(builder.Task.Logs[0].Logs); got != 2 {
+		t.Errorf("expected 2 executor logs, got %d", got)
+	}
+
+	if task.State != tes.State_COMPLETE {
+		t.Errorf("expected state COMPLETE, got %s", task.State)
+	}
+}
+
 func TestWorkerRunFileTaskReader(t *testing.T) {
 	tests.SetLogOutput(log, t)
 	c := tests.DefaultConfig()

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -196,8 +196,15 @@ func (r *DefaultWorker) Run(pctx context.Context) (runerr error) {
 			resources = &tes.Resources{}
 		}
 
-		ignoreError := false
 		for i, d := range task.GetExecutors() {
+			// If a previous executor failed and its error was not to be ignored,
+			// stop before creating any state (executor writer, log slot, etc.) for
+			// this executor. Creating the writer above would otherwise emit an empty
+			// executor log entry for an executor that never ran.
+			if !run.ok() {
+				break
+			}
+
 			var command = Command{
 				Image:        d.Image,
 				ShellCommand: d.Command,
@@ -285,11 +292,11 @@ func (r *DefaultWorker) Run(pctx context.Context) (runerr error) {
 			// stdout/stderr directly via its PVC mount. Creating host files here
 			// would poison the Mountpoint inode, making the file unreadable by
 			// the worker's mount instance (EPERM).
-			if (run.ok() || ignoreError) && r.Executor.Backend != "kubernetes" {
+			if r.Executor.Backend != "kubernetes" {
 				run.syserr = r.openStepLogs(mapper, s, d)
 			}
 
-			if run.ok() || ignoreError {
+			if run.ok() {
 				err := s.Run(ctx)
 
 				if err != nil {
@@ -309,10 +316,15 @@ func (r *DefaultWorker) Run(pctx context.Context) (runerr error) {
 					default:
 						run.execerr = err
 					}
+
+					// If this executor declared that its errors should be ignored,
+					// clear the executor error so subsequent executors still run.
+					// System errors are never ignored.
+					if run.execerr != nil && d.GetIgnoreError() {
+						run.execerr = nil
+					}
 				}
 			}
-
-			ignoreError = d.GetIgnoreError()
 		}
 	}
 


### PR DESCRIPTION
# Overview ⚙️

This PR resolves a number of failures encountered when running the [GA4GH TES Compliance Tests](https://github.com/elixir-cloud-aai/openapi-test-runner) against Funnel on Kubernetes with the Postgres backend.

It fixes three distinct bugs, each surfaced by the compliance suite:

1. A **server panic** when marshaling tasks that have no logs yet.
2. A **phantom executor log** emitted by the worker for executors that never ran.
3. The same **phantom executor log** persisting via the Postgres backend, which pre-allocates a log slot per executor at task creation.

## Current Behavior ⚠️

- **Panic on submit.** Listing or fetching a freshly-submitted task (`view=BASIC`/`FULL`) could crash the gRPC gateway with `runtime error: index out of range [0] with length 0`. `CustomMarshal.DetectView` indexed `task.Logs[0]` without checking that `Logs` was non-empty — a just-created task has a `creation_time` but no logs yet.
- **Phantom executor logs.** When an executor failed with `ignore_error: false`, the task correctly stopped, but an **empty placeholder log** (`exit_code: 0`, empty `start_time`) was still recorded for the executor(s) that never ran. The compliance test `create_task_ignore_error` expects exactly one executor log when the first executor fails; Funnel returned two. The worker loop created an executor event-writer at the top of every iteration before checking whether the executor would actually run, and the `ignore_error` flag was applied from the *previous* executor rather than the failing one.
- **Postgres pre-allocation.** Independently of the worker, the Postgres backend pre-allocated one empty `ExecutorLog` per executor at task creation (necessary because `jsonb_set` cannot grow a JSON array in place). Slots for executors that never ran remained as empty placeholders in the stored task, so the phantom log reappeared on read even after the worker fix. (The Badger and Datastore backends grow the log array lazily and were not affected.)

## New Behavior ✔️

- **`server/marshal.go`** — `DetectView` now guards the index (`len(task.Logs) == 0 || len(task.Logs[0].SystemLogs) == 0`) and returns the BASIC view for a task with no logs instead of panicking.
- **`worker/worker.go`** — the executor loop now `break`s before creating any state (event writer, log slot) for an executor when a prior executor failed and its error was not ignored. The current executor's own `ignore_error` is consulted to decide whether to clear the executor error and continue. System errors are never ignored.
- **`database/postgres/tes.go`** — `GetTask` and `ListTasks` now trim trailing executor logs that never started (`start_time == ""`), matching the lazily-grown shape produced by the other backends. This is applied at read time so the JSONB write path (which relies on the pre-allocated slots for `jsonb_set`) is left untouched.

### Tests

- `server/marshal_test.go` — `TestDetectView_EmptyLogsDoesNotPanic`, `TestMarshalList_FirstTaskWithEmptyLogs` (regression for the panic).
- `tests/core/worker_test.go` — `TestExecutorErrorStopsTask` (`ignore_error: false` ⇒ 1 log, `EXECUTOR_ERROR`) and `TestExecutorIgnoreErrorContinuesTask` (`ignore_error: true` ⇒ 2 logs, `COMPLETE`). These are Docker-backed integration tests in `tests/core`, mirroring the compliance scenario.
- `database/postgres/tes_test.go` — `TestTrimUnusedExecutorLogs` table tests + a no-logs no-panic case (pure unit tests, no container required).

## Breaking Changes? ❌

- [x] None. API responses become *more* spec-compliant (no phantom executor logs); no request/response schema or config changes.

## Next Steps 🌀

- Re-run the full GA4GH compliance suite against the Postgres + Kubernetes deployment to confirm `create_task_ignore_error` (Test-19) and the previously-panicking list/get cases now pass.
