### PR TITLE
fix: Integration Tests

### DIFF
--- a/.github/workflows/integration_tests_on_kind.yaml
+++ b/.github/workflows/integration_tests_on_kind.yaml
@@ -19,8 +19,10 @@ jobs:
       # Pin the integration test code (gen3-code-vigil) to the last known-good
       # commit. On master, conftest.py:180 now calls get_navigation_url(), which
       # crashes with KeyError: 'navigation' against the kind portal config.
-      # 891ea9e is the commit from the last green run (calypr/funnel run 27659443374).
-      TEST_REPO_BRANCH: "891ea9eaf18fa3ce114483af5cbcdd9356ce31c9"
+      # 69c620a ("Gen3SDK Tests (#558)") is the gen3-code-vigil commit from the
+      # last green run (calypr/funnel run 27659443374); its conftest.py predates
+      # the get_navigation_url call.
+      TEST_REPO_BRANCH: "69c620a62f3deb4be8ca19a858701519d18a462b"
       SETUP_SCRIPT_1: https://raw.githubusercontent.com/uc-cdis/gen3-workflow/refs/heads/master/.github/workflows/integration_tests_on_kind/ci_start_kind_cluster.sh
       SETUP_SCRIPT_2: https://raw.githubusercontent.com/uc-cdis/gen3-workflow/refs/heads/master/.github/workflows/integration_tests_on_kind/ci_override_config_and_start_minio.sh
       SETUP_SCRIPT_3: https://raw.githubusercontent.com/uc-cdis/gen3-workflow/refs/heads/master/.github/workflows/integration_tests_on_kind/ci_expose_kind_cluster.sh

--- a/.github/workflows/integration_tests_on_kind.yaml
+++ b/.github/workflows/integration_tests_on_kind.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   integration_tests:
     name: Integration tests
-    uses: uc-cdis/.github/.github/workflows/integration_tests.yaml@28f8020ea479e0b79e9a86bdfb9da6566806cf3b
+    uses: uc-cdis/.github/.github/workflows/integration_tests.yaml@master
     with:
       QUAY_ORG: ohsu-comp-bio
       EXTERNAL_TO_CTDS: "true"

--- a/.github/workflows/integration_tests_on_kind.yaml
+++ b/.github/workflows/integration_tests_on_kind.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   integration_tests:
     name: Integration tests
-    uses: uc-cdis/.github/.github/workflows/integration_tests.yaml@master
+    uses: uc-cdis/.github/.github/workflows/integration_tests.yaml@28f8020ea479e0b79e9a86bdfb9da6566806cf3b
     with:
       QUAY_ORG: ohsu-comp-bio
       EXTERNAL_TO_CTDS: "true"

--- a/.github/workflows/integration_tests_on_kind.yaml
+++ b/.github/workflows/integration_tests_on_kind.yaml
@@ -16,6 +16,11 @@ jobs:
       QUAY_ORG: ohsu-comp-bio
       EXTERNAL_TO_CTDS: "true"
       SERVICE_TO_TEST: gen3_workflow
+      # Pin the integration test code (gen3-code-vigil) to the last known-good
+      # commit. On master, conftest.py:180 now calls get_navigation_url(), which
+      # crashes with KeyError: 'navigation' against the kind portal config.
+      # 891ea9e is the commit from the last green run (calypr/funnel run 27659443374).
+      TEST_REPO_BRANCH: "891ea9eaf18fa3ce114483af5cbcdd9356ce31c9"
       SETUP_SCRIPT_1: https://raw.githubusercontent.com/uc-cdis/gen3-workflow/refs/heads/master/.github/workflows/integration_tests_on_kind/ci_start_kind_cluster.sh
       SETUP_SCRIPT_2: https://raw.githubusercontent.com/uc-cdis/gen3-workflow/refs/heads/master/.github/workflows/integration_tests_on_kind/ci_override_config_and_start_minio.sh
       SETUP_SCRIPT_3: https://raw.githubusercontent.com/uc-cdis/gen3-workflow/refs/heads/master/.github/workflows/integration_tests_on_kind/ci_expose_kind_cluster.sh


### PR DESCRIPTION
# Overview

~This PR reverts Funnel's Cancel Task Response from `204` to `200` in order to correctly follow TES spec!~

_Edit:_ The initial `204` response update was added in Commit [b95f279](https://github.com/calypr/funnel/pull/1433/changes/b95f2797ab82d43c28235d242fa7021d2da94e52)) + reverted in Commit [96f78c2](https://github.com/calypr/funnel/commit/96f78c2491b0f62697ee097121ff9de159beab12), both in PR #1433.

This PR was then created afterwards, but only deals with Integration Test issues (not response codes).