### PR TITLE
feat: Add initial `funnel k8s cleanup` command

### DIFF
--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -27,8 +27,9 @@ import (
 
 // Cmd is the root "funnel kubernetes" command.
 var Cmd = &cobra.Command{
-	Use:   "kubernetes",
-	Short: "Funnel Kubernetes management commands.",
+	Use:     "kubernetes",
+	Aliases: []string{"k8s"},
+	Short:   "Funnel Kubernetes management commands.",
 }
 
 func init() {
@@ -67,11 +68,13 @@ is decoupled from the server lifecycle and multiple replicas do not race.`,
 				return fmt.Errorf("opening database: %v", err)
 			}
 
-			// TODO: Why are we building a new backend here?
-			// Build the K8s backend (connects to the cluster via in-cluster config).
-			// We pass a no-op event writer since this command only deletes resources
-			// and never needs to emit task state events.
-			backend, err := k8sbackend.NewBackend(ctx, conf, reader, &events.Logger{Log: log}, log)
+			// Build a cleanup-only K8s backend. This connects to the same cluster as
+			// the running Funnel Server (via in-cluster config) but, unlike the full
+			// server backend, does not require a worker job template and does not start
+			// the reconcile goroutine — cleanup only reads the database and deletes
+			// orphaned resources. The event writer just logs, since cleanup never emits
+			// task state events.
+			backend, err := k8sbackend.NewCleanupBackend(conf, reader, &events.Logger{Log: log}, log)
 			if err != nil {
 				return fmt.Errorf("initializing kubernetes backend: %v", err)
 			}
@@ -79,8 +82,13 @@ is decoupled from the server lifecycle and multiple replicas do not race.`,
 			log.Info("Starting orphaned resource cleanup",
 				"namespace", conf.Kubernetes.JobsNamespace)
 
-			backend.ReconcileOnce()
-			// backend.CleanOrphanedResources(ctx)
+			// Delete Funnel-managed resources whose task is gone or terminal.
+			//
+			// TODO: Once the modular reconciler lands (calypr/funnel#1438, #1410)
+			// this should call the full single-pass reconcile (reconcileOnce) so the
+			// CronJob also reconciles task/job state, not just orphaned resources.
+			backend.CleanOrphanedResources(ctx)
+
 			log.Info("Orphaned resource cleanup complete")
 			return nil
 		},

--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -67,6 +67,7 @@ is decoupled from the server lifecycle and multiple replicas do not race.`,
 				return fmt.Errorf("opening database: %v", err)
 			}
 
+			// TODO: Why are we building a new backend here?
 			// Build the K8s backend (connects to the cluster via in-cluster config).
 			// We pass a no-op event writer since this command only deletes resources
 			// and never needs to emit task state events.
@@ -77,7 +78,9 @@ is decoupled from the server lifecycle and multiple replicas do not race.`,
 
 			log.Info("Starting orphaned resource cleanup",
 				"namespace", conf.Kubernetes.JobsNamespace)
-			backend.CleanOrphanedResources(ctx)
+
+			backend.ReconcileOnce()
+			// backend.CleanOrphanedResources(ctx)
 			log.Info("Orphaned resource cleanup complete")
 			return nil
 		},

--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -82,12 +82,8 @@ is decoupled from the server lifecycle and multiple replicas do not race.`,
 			log.Info("Starting orphaned resource cleanup",
 				"namespace", conf.Kubernetes.JobsNamespace)
 
-			// Delete Funnel-managed resources whose task is gone or terminal.
-			//
-			// TODO: Once the modular reconciler lands (calypr/funnel#1438, #1410)
-			// this should call the full single-pass reconcile (reconcileOnce) so the
-			// CronJob also reconciles task/job state, not just orphaned resources.
-			backend.CleanOrphanedResources(ctx)
+			// Reconcile task/job state and delete resources whose task is gone or terminal.
+			backend.ReconcileOnce(ctx, false)
 
 			log.Info("Orphaned resource cleanup complete")
 			return nil

--- a/compute/kubernetes/backend.go
+++ b/compute/kubernetes/backend.go
@@ -75,6 +75,41 @@ func NewBackend(ctx context.Context, conf *config.Config, reader tes.ReadOnlySer
 	return b, nil
 }
 
+// NewCleanupBackend returns a Backend suitable for one-shot resource cleanup
+// (e.g. the "funnel kubernetes cleanup" command run as a CronJob).
+//
+// Unlike NewBackend, it does not require a worker job template and does not start
+// the reconcile goroutine: cleanup only reads the database and deletes orphaned
+// Kubernetes resources, so the task-submission configuration is irrelevant. Like
+// the server backend, it connects to the same cluster via in-cluster config and
+// is intended to run inside the cluster (e.g. as a CronJob).
+func NewCleanupBackend(conf *config.Config, reader tes.ReadOnlyServer, writer events.Writer, log *logger.Logger) (*Backend, error) {
+	// Resolve the namespace cleanup should operate in. Prefer the configured
+	// namespace; otherwise fall back to the pod's ServiceAccount namespace.
+	if conf.Kubernetes.JobsNamespace == "" {
+		conf.Kubernetes.JobsNamespace = conf.Kubernetes.Namespace
+	}
+	if conf.Kubernetes.JobsNamespace == "" {
+		conf.Kubernetes.JobsNamespace = k8sutil.InClusterNamespace()
+	}
+	if conf.Kubernetes.JobsNamespace == "" {
+		return nil, fmt.Errorf("could not determine kubernetes namespace; set Kubernetes.Namespace in config")
+	}
+
+	clientset, err := k8sutil.NewK8sClient(conf)
+	if err != nil {
+		return nil, fmt.Errorf("creating kubernetes client: %v", err)
+	}
+
+	return &Backend{
+		client:   clientset,
+		event:    writer,
+		database: reader,
+		log:      log,
+		conf:     conf,
+	}, nil
+}
+
 func (b Backend) CheckBackendParameterSupport(task *tes.Task) error {
 	if !task.Resources.GetBackendParametersStrict() {
 		return nil

--- a/compute/kubernetes/backend.go
+++ b/compute/kubernetes/backend.go
@@ -951,6 +951,18 @@ func (b *Backend) isResourceCleanupNeeded(ctx context.Context, taskID string) (b
 	}
 }
 
+// ReconcileOnce performs a single reconciliation pass over Funnel-managed Kubernetes
+// resources. It is intended to be invoked by an external scheduler (e.g. a Kubernetes
+// CronJob configured via the Helm chart's ReconcileRate value) so that reconciliation
+// is decoupled from the Funnel server lifecycle and multiple server replicas do not
+// race to reconcile the same resources.
+//
+// This is currently a stub that simply logs; the full reconciliation logic is added in
+// https://github.com/calypr/funnel/pull/1438.
+func (b *Backend) ReconcileOnce() {
+	b.log.Info("Reconciling!")
+}
+
 // CleanOrphanedResources deletes any Funnel-managed Kubernetes resources that are not associated
 // with an active task in the database.
 //

--- a/compute/kubernetes/backend.go
+++ b/compute/kubernetes/backend.go
@@ -771,8 +771,15 @@ func (b *Backend) reconcileJob(ctx context.Context, j *v1.Job, disableCleanup bo
 	}
 }
 
-// reconcileOnce performs a single reconciliation pass.
-func (b *Backend) reconcileOnce(ctx context.Context, disableCleanup bool) {
+// ReconcileOnce performs a single reconciliation pass over Funnel-managed Kubernetes
+// resources. It is intended to be invoked by an external scheduler (e.g. a Kubernetes
+// CronJob configured via the Helm chart's ReconcileRate value) so that reconciliation
+// is decoupled from the Funnel server lifecycle and multiple server replicas do not
+// race to reconcile the same resources.
+//
+// This is currently a stub that simply logs; the full reconciliation logic is added in
+// https://github.com/calypr/funnel/pull/1438.
+func (b *Backend) ReconcileOnce(ctx context.Context, disableCleanup bool) {
 	k8sJobs, err := b.listAllWorkerJobs(ctx)
 	if err != nil {
 		b.log.Error("reconcile: listing jobs", err)
@@ -835,7 +842,7 @@ func (b *Backend) reconcile(ctx context.Context, rate time.Duration, disableClea
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			b.reconcileOnce(ctx, disableCleanup)
+			b.ReconcileOnce(ctx, disableCleanup)
 		}
 	}
 }
@@ -873,18 +880,6 @@ func (b *Backend) isResourceCleanupNeeded(ctx context.Context, taskID string) (b
 	default:
 		return false, nil
 	}
-}
-
-// ReconcileOnce performs a single reconciliation pass over Funnel-managed Kubernetes
-// resources. It is intended to be invoked by an external scheduler (e.g. a Kubernetes
-// CronJob configured via the Helm chart's ReconcileRate value) so that reconciliation
-// is decoupled from the Funnel server lifecycle and multiple server replicas do not
-// race to reconcile the same resources.
-//
-// This is currently a stub that simply logs; the full reconciliation logic is added in
-// https://github.com/calypr/funnel/pull/1438.
-func (b *Backend) ReconcileOnce() {
-	b.log.Info("Reconciling!")
 }
 
 // CleanOrphanedResources deletes any Funnel-managed Kubernetes resources that are not associated

--- a/util/k8sutil/k8s.go
+++ b/util/k8sutil/k8s.go
@@ -2,18 +2,23 @@ package k8sutil
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/ohsu-comp-bio/funnel/config"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
-// NewK8sClient returns a new Kubernetes client.
-func NewK8sClient(conf *config.Config) (*kubernetes.Clientset, error) {
-	var kubeconfig *rest.Config
-	var err error
+// inClusterNamespaceFile is the path to the namespace file that Kubernetes
+// mounts into every pod via its ServiceAccount.
+const inClusterNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 
-	kubeconfig, err = rest.InClusterConfig()
+// NewK8sClient returns a new Kubernetes client using in-cluster configuration.
+// Funnel's Kubernetes commands (server and cleanup CronJob alike) are designed to
+// run inside the cluster, so only in-cluster config is supported.
+func NewK8sClient(conf *config.Config) (*kubernetes.Clientset, error) {
+	kubeconfig, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, fmt.Errorf("building in-cluster kubeconfig: %v", err)
 	}
@@ -24,4 +29,15 @@ func NewK8sClient(conf *config.Config) (*kubernetes.Clientset, error) {
 	}
 
 	return clientset, nil
+}
+
+// InClusterNamespace returns the namespace the current pod's ServiceAccount is
+// bound to, read from the file Kubernetes mounts into every pod. It returns an
+// empty string when not running inside a cluster.
+func InClusterNamespace() string {
+	data, err := os.ReadFile(inClusterNamespaceFile)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
 }


### PR DESCRIPTION
## Description

Adds an initial `funnel kubernetes cleanup` command that deletes orphaned Funnel-managed Kubernetes resources (PVs, ServiceAccounts, executor jobs) whose task is no longer present or is in a terminal state. It is designed to run inside the cluster as a CronJob — the "external reconciler" — so that resource cleanup is decoupled from the Funnel Server lifecycle and multiple server replicas do not race to clean the same resources.

The command reuses the running server's configuration and connects to the same cluster; it does **not** stand up a second compute backend or require a worker job template.

### Changes

- **`cmd/kubernetes/kubernetes.go`**
  - New `funnel kubernetes cleanup` subcommand. Opens only the configured Funnel database (no HTTP/gRPC server) and runs `CleanOrphanedResources`.
  - Add a `k8s` alias for the `kubernetes` command group, matching the backend name which already accepts both `kubernetes` and `k8s`.
- **`compute/kubernetes/backend.go`**
  - New `NewCleanupBackend` constructor: a cleanup-only backend that, unlike `NewBackend`, does not require a worker job template and does not start the reconcile goroutine. It only needs a k8s client, a DB reader, and config.
  - Resolves the target namespace from config, falling back to `JobsNamespace` and then the pod's ServiceAccount namespace.
- **`util/k8sutil/k8s.go`**
  - Add `InClusterNamespace`, which reads the namespace from the pod's mounted ServiceAccount, so the CronJob works without an explicitly configured namespace.

## Motivation and Context

K8s resource cleanup currently runs inside the Funnel Server via the reconcile goroutine, coupling it to the server lifecycle and causing replicas to race. This command is the CLI entry point for running that cleanup as an independent, schedulable CronJob.

Related PRs:

- calypr/funnel#1438 and calypr/funnel#1410 — modularize the reconciler so a single pass (`reconcileOnce`) can be invoked externally. Once those land, this command should call the full single-pass reconcile rather than only `CleanOrphanedResources` (tracked by a `TODO` in `cmd/kubernetes/kubernetes.go`).
- calypr/helm-charts#22 — adds the CronJob that invokes `funnel kubernetes cleanup --config /etc/config/funnel-server.yaml` and derives its schedule from `Kubernetes.ReconcileRate`.

## How Has This Been Tested?

- Builds and `go vet` pass locally.
- `funnel k8s --help` / `funnel kubernetes --help` resolve to the same command group (alias verified).
- The command is intended to run **in-cluster** (it uses in-cluster config). It can be exercised by triggering the CronJob from calypr/helm-charts#22, e.g. `kubectl create job --from=cronjob/funnel-cleanup-<namespace> funnel-cleanup-manual`.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] I have updated the documentation accordingly (link here).
- [ ] I have tested that this feature locally.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Reviewer has tested this feature locally
