### PR TITLE
fix(k8s): re-establish pod watch on server timeout for long-running tasks

### DIFF
--- a/worker/kubernetes.go
+++ b/worker/kubernetes.go
@@ -246,19 +246,9 @@ func (kcmd KubernetesCommand) Run(ctx context.Context) error {
 	}
 
 	logger.Debug("Job created successfully, waiting for pod to finish", "jobName", job.Name)
-	podWatcher, err := clientset.CoreV1().Pods(kcmd.JobsNamespace).Watch(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("job-name=%s-%d", taskId, kcmd.JobId),
-	})
-	if err != nil {
-		return &K8sSystemErr{
-			Reason:  "PodWatcherCreationFailed",
-			Message: "Failed to create pod watcher",
-			Err:     err,
-		}
-	}
-	defer podWatcher.Stop()
 	executorJobName := fmt.Sprintf("%s-%d", taskId, kcmd.JobId)
-	pod, err := waitForPodFinish(ctx, podWatcher)
+	podLabelSelector := fmt.Sprintf("job-name=%s", executorJobName)
+	pod, err := waitForPodFinish(ctx, clientset, kcmd.JobsNamespace, podLabelSelector)
 	if err != nil {
 		var sysErr *K8sSystemErr
 		if errors.As(err, &sysErr) && slices.Contains(terminalWaitingReasons, sysErr.Reason) {
@@ -403,30 +393,85 @@ var terminalWaitingReasons = []string{
 
 // waitForPodFinish watches pod events until the container terminates, a
 // terminal waiting state is detected, or the context is cancelled.
-func waitForPodFinish(ctx context.Context, watcher watch.Interface) (*corev1.Pod, error) {
+//
+// The Kubernetes API server closes long-lived watch connections after a
+// (server-configured) timeout, which for long-running tasks routinely fires
+// after ~20-30 minutes. When that happens the watch's result channel is
+// closed, which is NOT an error — the watch must simply be re-established,
+// resuming from the last observed resourceVersion. Failing to distinguish
+// this case from a genuinely missing pod previously caused long-running tasks
+// to be marked SYSTEM_ERROR ("received nil pod object from watcher").
+func waitForPodFinish(ctx context.Context, clientset kubernetes.Interface, namespace, labelSelector string) (*corev1.Pod, error) {
 	// wait up to 5 min for the pod to appear
 	appearanceTimer := time.NewTimer(5 * 60 * time.Second)
 	defer appearanceTimer.Stop()
 
+	// resourceVersion tracks the last pod event we observed so a re-established
+	// watch resumes where the previous one left off rather than replaying old
+	// events or missing intervening ones.
+	var resourceVersion string
+
+	watcher, err := newPodWatcher(ctx, clientset, namespace, labelSelector, resourceVersion)
+	if err != nil {
+		return nil, &K8sSystemErr{
+			Reason:  "PodWatcherCreationFailed",
+			Message: "Failed to create pod watcher",
+			Err:     err,
+		}
+	}
+	defer func() { watcher.Stop() }()
+
 	for {
 		select {
-		case event := <-watcher.ResultChan():
+		case event, ok := <-watcher.ResultChan():
+			// A closed channel means the server ended the watch (e.g. the
+			// periodic watch timeout). Re-establish the watch and continue
+			// rather than treating this as a fatal error.
+			if !ok {
+				logger.Debug("pod watch channel closed; re-establishing watch", "resourceVersion", resourceVersion)
+				watcher.Stop()
+				watcher, err = newPodWatcher(ctx, clientset, namespace, labelSelector, resourceVersion)
+				if err != nil {
+					return nil, &K8sSystemErr{
+						Reason:  "PodWatcherCreationFailed",
+						Message: "Failed to re-establish pod watcher after watch timeout",
+						Err:     err,
+					}
+				}
+				continue
+			}
+
 			if event.Type == watch.Error {
+				// A "too old resource version" error means we cannot resume
+				// from our tracked version; restart the watch from scratch.
 				if status, ok := event.Object.(*metav1.Status); ok {
+					if status.Reason == metav1.StatusReasonExpired || status.Reason == metav1.StatusReasonGone {
+						logger.Debug("pod watch resourceVersion expired; restarting watch from latest", "message", status.Message)
+						resourceVersion = ""
+						watcher.Stop()
+						watcher, err = newPodWatcher(ctx, clientset, namespace, labelSelector, resourceVersion)
+						if err != nil {
+							return nil, &K8sSystemErr{
+								Reason:  "PodWatcherCreationFailed",
+								Message: "Failed to restart pod watcher after resourceVersion expiry",
+								Err:     err,
+							}
+						}
+						continue
+					}
 					return nil, fmt.Errorf("pod watch error: %s", status.Message)
 				}
 				return nil, fmt.Errorf("unknown pod watch error")
-			}
-
-			if event.Object == nil { // no pod; watcher times out
-				logger.Debug("received nil pod object from watcher")
-				return nil, fmt.Errorf("received nil pod object from watcher")
 			}
 
 			pod, ok := event.Object.(*corev1.Pod)
 			if !ok {
 				continue
 			}
+
+			// Track the latest resourceVersion so a re-established watch resumes
+			// from here.
+			resourceVersion = pod.ResourceVersion
 
 			// Pod exists: stop the appearance timer
 			appearanceTimer.Stop()
@@ -468,6 +513,17 @@ func waitForPodFinish(ctx context.Context, watcher watch.Interface) (*corev1.Pod
 			return nil, fmt.Errorf("context cancelled while waiting for pod termination")
 		}
 	}
+}
+
+// newPodWatcher establishes a watch on pods matching labelSelector. When
+// resourceVersion is non-empty the watch resumes from that version, allowing a
+// watch that was closed by the API server (e.g. the periodic watch timeout) to
+// be transparently re-established without replaying or missing events.
+func newPodWatcher(ctx context.Context, clientset kubernetes.Interface, namespace, labelSelector, resourceVersion string) (watch.Interface, error) {
+	return clientset.CoreV1().Pods(namespace).Watch(ctx, metav1.ListOptions{
+		LabelSelector:   labelSelector,
+		ResourceVersion: resourceVersion,
+	})
 }
 
 // Deletes a job and waits for it to be deleted

--- a/worker/kubernetes_test.go
+++ b/worker/kubernetes_test.go
@@ -1,0 +1,194 @@
+package worker
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+const (
+	testNamespace = "funnel"
+	testSelector  = "job-name=task-0"
+)
+
+func runningPod(resourceVersion string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "task-0-abc",
+			Namespace:       testNamespace,
+			ResourceVersion: resourceVersion,
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+}
+
+func terminatedPod(resourceVersion string, exitCode int32) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "task-0-abc",
+			Namespace:       testNamespace,
+			ResourceVersion: resourceVersion,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{ExitCode: exitCode},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestWaitForPodFinishReestablishesWatchOnTimeout simulates the Kubernetes API
+// server closing a long-lived watch connection (the ~20-30 min watch timeout
+// that previously caused long-running tasks to fail with "received nil pod
+// object from watcher"). The first watch emits a Running pod then closes its
+// channel; the second watch emits the terminated pod. waitForPodFinish must
+// transparently re-establish the watch and return the terminated pod rather
+// than erroring out.
+func TestWaitForPodFinishReestablishesWatchOnTimeout(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+
+	var mu sync.Mutex
+	var watchCount int
+	var resumedFrom []string
+
+	clientset.PrependWatchReactor("pods", func(action k8stesting.Action) (bool, watch.Interface, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		watchCount++
+		current := watchCount
+
+		// Record the resourceVersion the watch was resumed from.
+		if wa, ok := action.(k8stesting.WatchActionImpl); ok {
+			resumedFrom = append(resumedFrom, wa.WatchRestrictions.ResourceVersion)
+		}
+
+		fw := watch.NewFake()
+		switch current {
+		case 1:
+			// First watch: emit a Running pod, then simulate the server
+			// closing the connection (watch timeout) by stopping the watcher,
+			// which closes its result channel.
+			go func() {
+				fw.Modify(runningPod("100"))
+				time.Sleep(20 * time.Millisecond)
+				fw.Stop()
+			}()
+		default:
+			// Re-established watch: emit the terminated pod.
+			go func() {
+				fw.Modify(terminatedPod("101", 0))
+			}()
+		}
+		return true, fw, nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	pod, err := waitForPodFinish(ctx, clientset, testNamespace, testSelector)
+	if err != nil {
+		t.Fatalf("expected pod to finish, got error: %v", err)
+	}
+	if pod == nil {
+		t.Fatal("expected non-nil pod")
+	}
+	if len(pod.Status.ContainerStatuses) == 0 || pod.Status.ContainerStatuses[0].State.Terminated == nil {
+		t.Fatal("expected terminated container status")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if watchCount < 2 {
+		t.Fatalf("expected watch to be re-established at least once, watchCount=%d", watchCount)
+	}
+	// The re-established watch should resume from the last observed
+	// resourceVersion rather than starting over.
+	if len(resumedFrom) < 2 || resumedFrom[1] != "100" {
+		t.Fatalf("expected re-established watch to resume from resourceVersion 100, got %v", resumedFrom)
+	}
+}
+
+// TestWaitForPodFinishReturnsTerminatedPod verifies the happy path: a single
+// watch that emits a terminated pod returns it without error.
+func TestWaitForPodFinishReturnsTerminatedPod(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	clientset.PrependWatchReactor("pods", func(_ k8stesting.Action) (bool, watch.Interface, error) {
+		fw := watch.NewFake()
+		go func() {
+			fw.Modify(terminatedPod("1", 0))
+		}()
+		return true, fw, nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	pod, err := waitForPodFinish(ctx, clientset, testNamespace, testSelector)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pod == nil || len(pod.Status.ContainerStatuses) == 0 {
+		t.Fatal("expected terminated pod")
+	}
+}
+
+// TestWaitForPodFinishRestartsOnExpiredResourceVersion verifies that an
+// "Expired" / "Gone" watch error (HTTP 410, too-old resourceVersion) restarts
+// the watch from scratch instead of failing the task.
+func TestWaitForPodFinishRestartsOnExpiredResourceVersion(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+
+	var mu sync.Mutex
+	var watchCount int
+
+	clientset.PrependWatchReactor("pods", func(_ k8stesting.Action) (bool, watch.Interface, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		watchCount++
+		current := watchCount
+
+		fw := watch.NewFake()
+		switch current {
+		case 1:
+			go func() {
+				fw.Modify(runningPod("100"))
+				time.Sleep(20 * time.Millisecond)
+				fw.Error(&metav1.Status{Reason: metav1.StatusReasonExpired, Message: "too old resource version"})
+			}()
+		default:
+			go func() {
+				fw.Modify(terminatedPod("200", 0))
+			}()
+		}
+		return true, fw, nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	pod, err := waitForPodFinish(ctx, clientset, testNamespace, testSelector)
+	if err != nil {
+		t.Fatalf("expected watch to restart on expired resourceVersion, got error: %v", err)
+	}
+	if pod == nil || len(pod.Status.ContainerStatuses) == 0 {
+		t.Fatal("expected terminated pod after restart")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if watchCount < 2 {
+		t.Fatalf("expected watch to restart after expiry, watchCount=%d", watchCount)
+	}
+}


### PR DESCRIPTION
The Kubernetes API server closes long-lived watch connections after a server-configured timeout, which for long-running tasks routinely fires after ~20-30 minutes. When that happened, waitForPodFinish read a zero-value event from the closed result channel and returned "received nil pod object from watcher", marking the task SYSTEM_ERROR even though the pod was healthy and still running.

waitForPodFinish now owns the watch lifecycle: it detects a closed result channel (ok == false) and transparently re-establishes the watch, resuming from the last observed resourceVersion so no events are replayed or missed. An Expired/Gone (HTTP 410) watch error restarts the watch from latest instead of failing the task.

Adds tests covering: re-establishment on watch timeout (resuming from the tracked resourceVersion), the terminated-pod happy path, and restart on an expired resourceVersion.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

Assisted-by: Claude Code:claude [Claude Code]

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran -->
<!--- Describe how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I have updated the documentation accordingly (link here).
- [ ] I have tested that this feature locally.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Reviewer has tested this feature locally
