### PR TITLE
Show credentials inside Credential where they need to be

### DIFF
--- a/website/content/docs/security/basic.md
+++ b/website/content/docs/security/basic.md
@@ -40,8 +40,9 @@ so you will also need to configure the RPC client.
 
 ```yaml
 RPCClient:
-  User: funnel
-  Password: abc123
+  Credential:
+    User: funnel
+    Password: abc123
 ```
 
 Make sure to properly protect the configuration file so that it's not readable


### PR DESCRIPTION
## Description
This updates the example `RPCClient` configuration section to have the `User` and `Password` fields in the right place.

## Motivation and Context
This should fix #1446. In #1150 the `User` and `Password` fields of `RPCClient` were moved inside a field named `Credential`, but the documentation's example configuration still shows them at their old location.

## How Has This Been Tested?
I made my configuration look like this and started Funnel v0.11.14 and the server came up instead of rejecting the configuration.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] I have updated the documentation accordingly (link here).
- [X] I have tested that this feature locally.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Reviewer has tested this feature locally

I don't think the documentation is under test, right? Otherwise this would have been caught already.

I wrote this in the Github web editor, and I'm not set up with a real dev environment to run the test suite.
